### PR TITLE
Add IPython to setup.py install_requires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,7 @@ setup(
     packages=find_packages(exclude=['tests']),
     package_data={'itables': ['javascript/*.*']},
     tests_require=['pytest'],
-    install_requires=['pandas'],
+    install_requires=['IPython', 'pandas'],
     license='MIT',
     classifiers=['Development Status :: 3 - Alpha',
                  'License :: OSI Approved :: MIT License',


### PR DESCRIPTION
Make setup.py match the items from requirements.txt since setuptools doesn't read the latter.