### PR TITLE
first very naive version of integrating buttons

### DIFF
--- a/experiments/buttons/buttons.ipynb
+++ b/experiments/buttons/buttons.ipynb
@@ -2,135 +2,21 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": null,
    "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "application/javascript": [
-       "require.config({\n",
-       "    paths: {\n",
-       "        \"datatables.net\": \"https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min\",\n",
-       "\"datatables.net-buttons\": \"https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min\",\n",
-       "\"datatables.net-html5\": \"https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min\"\n",
-       "    }\n",
-       "});\n",
-       "\n",
-       "$('head').append('<style> table td { text-overflow: ellipsis; overflow: hidden; } </style>');\n",
-       "$('head').append('<link rel=\"stylesheet\" type=\"text/css\" href = \"https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css\" > ');\n",
-       "$('head').append('<link rel=\"stylesheet\" type=\"text/css\" href = \"https://cdn.datatables.net/buttons/1.6.5/css/buttons.dataTables.min.css\"');\n",
-       "\n",
-       "$('head').append(`<script>\n",
-       "function eval_functions(map_or_text) {\n",
-       "    if (typeof map_or_text === \"string\") {\n",
-       "        if (map_or_text.startsWith(\"function\")) {\n",
-       "            try {\n",
-       "                // Note: parenthesis are required around the whole expression for eval to return a value!\n",
-       "                // See https://stackoverflow.com/a/7399078/911298.\n",
-       "                //\n",
-       "                // eval(\"local_fun = \" + map_or_text) would fail because local_fun is not declared\n",
-       "                // (using var, let or const would work, but it would only be declared in the local scope\n",
-       "                // and therefore the value could not be retrieved).\n",
-       "                const func = eval(\"(\" + map_or_text + \")\");\n",
-       "                if (typeof func !== \"function\") {\n",
-       "                    // Note: backquotes are super convenient!\n",
-       "                    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals\n",
-       "                    console.error(\"Evaluated expression \" + map_or_text + \" is not a function (type is \" + typeof func + \")\");\n",
-       "                    return map_or_text;\n",
-       "                }\n",
-       "                // Return the function\n",
-       "                return func;\n",
-       "            } catch (e) {\n",
-       "                // Make sure to print the error with a second argument to console.error().\n",
-       "                console.error(\"itables was not able to parse \" + map_or_text, e);\n",
-       "            }\n",
-       "        }\n",
-       "    } else if (typeof map_or_text === \"object\") {\n",
-       "        if (map_or_text instanceof Array) {\n",
-       "            // Note: \"var\" is now superseded by \"let\" and \"const\".\n",
-       "            // https://medium.com/javascript-scene/javascript-es6-var-let-or-const-ba58b8dcde75\n",
-       "            const result = [];\n",
-       "            // Note: \"for of\" is the best way to iterate through an iterable.\n",
-       "            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of\n",
-       "            for (const item of map_or_text) {\n",
-       "                result.push(eval_functions(item));\n",
-       "            }\n",
-       "            return result;\n",
-       "\n",
-       "            // Alternatively, more functional approach in one line:\n",
-       "            // return map_or_text.map(eval_functions);\n",
-       "        } else {\n",
-       "            const result = {};\n",
-       "            // Object.keys() is safer than \"for in\" because otherwise you might have keys\n",
-       "            // that aren't defined in the object itself.\n",
-       "            //\n",
-       "            // See https://stackoverflow.com/a/684692/911298.\n",
-       "            for (const item of Object.keys(map_or_text)) {\n",
-       "                result[item] = eval_functions(map_or_text[item]);\n",
-       "            }\n",
-       "            return result;\n",
-       "        }\n",
-       "    }\n",
-       "\n",
-       "    return map_or_text;\n",
-       "}\n",
-       "</` + 'script>');"
-      ],
-      "text/plain": [
-       "<IPython.core.display.Javascript object>"
-      ]
-     },
-     "metadata": {},
-     "output_type": "display_data"
-    }
-   ],
+   "outputs": [],
    "source": [
     "import pandas as pd\n",
     "import itables.interactive\n",
-    "from itables import show"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 3,
-   "metadata": {},
-   "outputs": [
-    {
-     "data": {
-      "text/html": [
-       "<div><table id=\"01c766c5-3dc2-4d14-9dfb-2914bac13d4f\" class=\"display\"><thead>\n",
-       "    <tr style=\"text-align: right;\">\n",
-       "      \n",
-       "      <th>col1</th>\n",
-       "      <th>col2</th>\n",
-       "    </tr>\n",
-       "  </thead></table><script type=\"text/javascript\">require([\"datatables.net\",\"datatables.net-buttons\",\"datatables.net-html5\"]\n",
-       ", function (datatables) {\n",
-       "    $(document).ready(function () {        \n",
-       "        var dt_args = {\"columnDefs\": [{\"width\": \"70px\", \"targets\": \"_all\"}], \"paging\": false, \"data\": [[1, 3], [2, 4]]};\n",
-       "        dt_args = eval_functions(dt_args);\n",
-       "        table = $('#01c766c5-3dc2-4d14-9dfb-2914bac13d4f').DataTable(dt_args);\n",
-       "    });\n",
-       "})\n",
-       "</script>\n",
-       "</div>\n"
-      ],
-      "text/plain": [
-       "   col1  col2\n",
-       "0     1     3\n",
-       "1     2     4"
-      ]
-     },
-     "execution_count": 3,
-     "metadata": {},
-     "output_type": "execute_result"
-    }
-   ],
-   "source": [
-    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
-    "df = pd.DataFrame(data=d)\n",
-    "#show(df, dom ='Bfrtip', buttons=['csvHtml5'])\n",
-    "df"
+    "from itables import show\n",
+    "\n",
+    "itables.options.requiredModules.update({\n",
+    "    \"datatables.net-buttons\": \"https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min\",\n",
+    "    \"datatables.net-html5\": \"https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min\",\n",
+    "    \"datatables.net-select\": \"https://cdn.datatables.net/select/1.3.1/js/dataTables.select.min\"})\n",
+    "itables.options.requiredCss += [\n",
+    "    \"https://cdn.datatables.net/buttons/1.6.5/css/buttons.dataTables.min.css\",\n",
+    "    \"https://cdn.datatables.net/select/1.3.1/css/select.dataTables.min.css\"]\n"
    ]
   },
   {
@@ -138,7 +24,11 @@
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
+    "df = pd.DataFrame(data=d)\n",
+    "show(df, dom ='Bfrtip', buttons = ['csvHtml5'], select = True)"
+   ]
   },
   {
    "cell_type": "code",

--- a/experiments/buttons/buttons.ipynb
+++ b/experiments/buttons/buttons.ipynb
@@ -1,0 +1,185 @@
+{
+ "cells": [
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "application/javascript": [
+       "require.config({\n",
+       "    paths: {\n",
+       "        \"datatables.net\": \"https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min\",\n",
+       "\"datatables.net-buttons\": \"https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min\",\n",
+       "\"datatables.net-html5\": \"https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min\"\n",
+       "    }\n",
+       "});\n",
+       "\n",
+       "$('head').append('<style> table td { text-overflow: ellipsis; overflow: hidden; } </style>');\n",
+       "$('head').append('<link rel=\"stylesheet\" type=\"text/css\" href = \"https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css\" > ');\n",
+       "$('head').append('<link rel=\"stylesheet\" type=\"text/css\" href = \"https://cdn.datatables.net/buttons/1.6.5/css/buttons.dataTables.min.css\"');\n",
+       "\n",
+       "$('head').append(`<script>\n",
+       "function eval_functions(map_or_text) {\n",
+       "    if (typeof map_or_text === \"string\") {\n",
+       "        if (map_or_text.startsWith(\"function\")) {\n",
+       "            try {\n",
+       "                // Note: parenthesis are required around the whole expression for eval to return a value!\n",
+       "                // See https://stackoverflow.com/a/7399078/911298.\n",
+       "                //\n",
+       "                // eval(\"local_fun = \" + map_or_text) would fail because local_fun is not declared\n",
+       "                // (using var, let or const would work, but it would only be declared in the local scope\n",
+       "                // and therefore the value could not be retrieved).\n",
+       "                const func = eval(\"(\" + map_or_text + \")\");\n",
+       "                if (typeof func !== \"function\") {\n",
+       "                    // Note: backquotes are super convenient!\n",
+       "                    // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals\n",
+       "                    console.error(\"Evaluated expression \" + map_or_text + \" is not a function (type is \" + typeof func + \")\");\n",
+       "                    return map_or_text;\n",
+       "                }\n",
+       "                // Return the function\n",
+       "                return func;\n",
+       "            } catch (e) {\n",
+       "                // Make sure to print the error with a second argument to console.error().\n",
+       "                console.error(\"itables was not able to parse \" + map_or_text, e);\n",
+       "            }\n",
+       "        }\n",
+       "    } else if (typeof map_or_text === \"object\") {\n",
+       "        if (map_or_text instanceof Array) {\n",
+       "            // Note: \"var\" is now superseded by \"let\" and \"const\".\n",
+       "            // https://medium.com/javascript-scene/javascript-es6-var-let-or-const-ba58b8dcde75\n",
+       "            const result = [];\n",
+       "            // Note: \"for of\" is the best way to iterate through an iterable.\n",
+       "            // https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/for...of\n",
+       "            for (const item of map_or_text) {\n",
+       "                result.push(eval_functions(item));\n",
+       "            }\n",
+       "            return result;\n",
+       "\n",
+       "            // Alternatively, more functional approach in one line:\n",
+       "            // return map_or_text.map(eval_functions);\n",
+       "        } else {\n",
+       "            const result = {};\n",
+       "            // Object.keys() is safer than \"for in\" because otherwise you might have keys\n",
+       "            // that aren't defined in the object itself.\n",
+       "            //\n",
+       "            // See https://stackoverflow.com/a/684692/911298.\n",
+       "            for (const item of Object.keys(map_or_text)) {\n",
+       "                result[item] = eval_functions(map_or_text[item]);\n",
+       "            }\n",
+       "            return result;\n",
+       "        }\n",
+       "    }\n",
+       "\n",
+       "    return map_or_text;\n",
+       "}\n",
+       "</` + 'script>');"
+      ],
+      "text/plain": [
+       "<IPython.core.display.Javascript object>"
+      ]
+     },
+     "metadata": {},
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "import pandas as pd\n",
+    "import itables.interactive\n",
+    "from itables import show"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div><table id=\"01c766c5-3dc2-4d14-9dfb-2914bac13d4f\" class=\"display\"><thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      \n",
+       "      <th>col1</th>\n",
+       "      <th>col2</th>\n",
+       "    </tr>\n",
+       "  </thead></table><script type=\"text/javascript\">require([\"datatables.net\",\"datatables.net-buttons\",\"datatables.net-html5\"]\n",
+       ", function (datatables) {\n",
+       "    $(document).ready(function () {        \n",
+       "        var dt_args = {\"columnDefs\": [{\"width\": \"70px\", \"targets\": \"_all\"}], \"paging\": false, \"data\": [[1, 3], [2, 4]]};\n",
+       "        dt_args = eval_functions(dt_args);\n",
+       "        table = $('#01c766c5-3dc2-4d14-9dfb-2914bac13d4f').DataTable(dt_args);\n",
+       "    });\n",
+       "})\n",
+       "</script>\n",
+       "</div>\n"
+      ],
+      "text/plain": [
+       "   col1  col2\n",
+       "0     1     3\n",
+       "1     2     4"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "d = {'col1': [1, 2], 'col2': [3, 4]}\n",
+    "df = pd.DataFrame(data=d)\n",
+    "#show(df, dom ='Bfrtip', buttons=['csvHtml5'])\n",
+    "df"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.6"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 4
+}

--- a/itables/__init__.py
+++ b/itables/__init__.py
@@ -1,13 +1,4 @@
 from .javascript import show, load_datatables
 from .version import __version__
 
-load_datatables(
-    required_modules={
-        "datatables.net": 'https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min',
-        "datatables.net-buttons": "https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min",
-        "datatables.net-html5": "https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min"},
-    required_css=[
-        '<link rel="stylesheet" type="text/css" href = "https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" > ',
-        '<link rel="stylesheet" type="text/css" href = "https://cdn.datatables.net/buttons/1.6.5/css/buttons.dataTables.min.css"'])
-
 __all__ = ['__version__', 'show']

--- a/itables/__init__.py
+++ b/itables/__init__.py
@@ -1,6 +1,13 @@
 from .javascript import show, load_datatables
 from .version import __version__
 
-load_datatables()
+load_datatables(
+    required_modules={
+        "datatables.net": 'https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min',
+        "datatables.net-buttons": "https://cdn.datatables.net/buttons/1.6.5/js/dataTables.buttons.min",
+        "datatables.net-html5": "https://cdn.datatables.net/buttons/1.6.5/js/buttons.html5.min"},
+    required_css=[
+        '<link rel="stylesheet" type="text/css" href = "https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css" > ',
+        '<link rel="stylesheet" type="text/css" href = "https://cdn.datatables.net/buttons/1.6.5/css/buttons.dataTables.min.css"'])
 
 __all__ = ['__version__', 'show']

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -12,6 +12,7 @@ import pandas.io.formats.format as fmt
 from IPython.core.display import display, Javascript, HTML
 import itables.options as opt
 from .downsample import downsample
+import string
 
 logging.basicConfig()
 logger = logging.getLogger(__name__)
@@ -27,10 +28,22 @@ def read_package_file(*path):
     with io.open(os.path.join(current_path, *path), encoding='utf-8') as fp:
         return fp.read()
 
-
-def load_datatables():
+__required_modules__ = {}
+def load_datatables(required_modules, required_css):
     """Load the datatables.net library, and the corresponding css"""
+    global __required_modules__
+    __required_modules__ = required_modules
+    required_modules_str = ",\n".join(['"{}": "{}"'.format(module, link) for module, link in required_modules.items()])
+
     load_datatables_js = read_package_file('javascript', 'load_datatables_connected.js')
+    load_datatables_js = string.Template(load_datatables_js).substitute(
+        paths=required_modules_str)
+
+    required_css_str = ""
+    for css in required_css:
+        required_css_str += "$('head').append('{}');\n".format(css)
+    load_datatables_js += required_css_str
+
     eval_functions_js = read_package_file('javascript', 'eval_functions.js')
     load_datatables_js += "\n$('head').append(`<script>\n" + eval_functions_js + "\n</` + 'script>');"
 
@@ -107,10 +120,12 @@ def _datatables_repr_(df=None, tableId=None, **kwargs):
     kwargs['data'] = _formatted_values(df.reset_index() if showIndex else df)
 
     try:
+        global __required_modules__
+
         dt_args = json.dumps(kwargs)
-        return """<div>""" + html_table + """
-<script type="text/javascript">
-require(["datatables"], function (datatables) {
+        value_str = """<div>""" + html_table + '<script type="text/javascript">require([{}]'.format(
+            ",".join(['"{}"'.format(module) for module in __required_modules__.keys()])) + """
+, function (datatables) {
     $(document).ready(function () {        
         var dt_args = """ + dt_args + """;
         dt_args = eval_functions(dt_args);
@@ -120,6 +135,7 @@ require(["datatables"], function (datatables) {
 </script>
 </div>
 """
+        return value_str
     except TypeError as error:
         logger.error(str(error))
         return ''

--- a/itables/javascript/load_datatables_connected.js
+++ b/itables/javascript/load_datatables_connected.js
@@ -1,10 +1,7 @@
 require.config({
     paths: {
-        datatables: 'https://cdn.datatables.net/1.10.19/js/jquery.dataTables.min',
+        $paths
     }
 });
 
-$('head').append('<link rel="stylesheet" type="text/css" \
-                href = "https://cdn.datatables.net/1.10.19/css/jquery.dataTables.min.css" > ');
-
-$('head').append('<style> table td { text-overflow: ellipsis; overflow: hidden; } </style>');
+$$('head').append('<style> table td { text-overflow: ellipsis; overflow: hidden; } </style>');

--- a/itables/options.py
+++ b/itables/options.py
@@ -16,3 +16,9 @@ maxBytes = 2 ** 16
 
 """Default column width for large tables"""
 columnDefs = [{'width': '70px', 'targets': "_all"}]
+
+"""Datatables required modules"""
+requiredModules = {"datatables.net": 'https://cdn.datatables.net/1.10.22/js/jquery.dataTables.min'}
+
+"""Datatables required css"""
+requiredCss = ["https://cdn.datatables.net/1.10.22/css/jquery.dataTables.min.css"]


### PR DESCRIPTION
This is a very naive version that integrates basic functionalities for buttons' extentions. I don't expect this to be merged, just give me guidance for getting this integrated.

* experiments/buttons/buttons.ipynb contains an example of using buttons.
* itables/__init__.py is currently responsible of calling load_datatables() with the new "required" modules/css. This should be located elsewhere for the user to specify. Where do you want me to put that?
