### PR TITLE
Load datatables.net with an ES import when `require.js` is not available

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 
 Changed
 -------
+- We load the `datatables.net` library with an ES import when `require.js` is not available. Now `itables` should also work in Jupyter Lab, VS Code and Colab (#3, #40)
 - The `show` function (and `itables.options`) has a new argument `eval_functions`. When set to `True`, the nested strings passed to `datatables.net` that start with `function` are converted to Javascript functions.
 - The HTML code for the datatables.net representation of the table is generated with an HTML template.
 - We use f-strings and thus require Python >= 3.6

--- a/itables/datatables_template.html
+++ b/itables/datatables_template.html
@@ -15,10 +15,27 @@
     const data = [];
     dt_args["data"] = data;
 
-    require(["jquery", "datatables"], ($, datatables) => {
+    if (typeof require === 'undefined') {
+        // TODO: This should become the default (use a simple import)
+        // when the ESM version works independently of whether
+        // require.js is there or not, see
+        // https://datatables.net/forums/discussion/69066/esm-es6-module-support?
+        const { default: $ } = await import("https://esm.sh/jquery@3.5.0");
+        const { default: initDataTables } = await import("https://esm.sh/datatables.net@1.11.3?deps=jquery@3.5.0");
+
+        initDataTables();
+
+        // Display the table
+        $(document).ready(function () {
+            $('#table_id').DataTable(dt_args);
+        });
+    } else {
+        require(["jquery", "datatables"], ($, datatables) => {
                 // Display the table
                 $(document).ready(function () {
                     $('#table_id').DataTable(dt_args);
                 });
-            });
+            }
+        )
+    }
 </script>

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -81,11 +81,11 @@ def _formatted_values(df):
     return formatted_df.values.tolist()
 
 
-def replace_value(template, pattern, value):
+def replace_value(template, pattern, value, count=1):
     """Set the given pattern to the desired value in the template,
     after making sure that the pattern is found exactly once."""
     assert isinstance(template, str)
-    assert template.count(pattern) == 1
+    assert template.count(pattern) == count
     return template.replace(pattern, value)
 
 
@@ -144,7 +144,7 @@ def _datatables_repr_(df=None, tableId=None, **kwargs):
         '<table id="table_id"><thead><tr><th>A</th></tr></thead></table>',
         table_header,
     )
-    output = replace_value(output, "#table_id", f"#{tableId}")
+    output = replace_value(output, "#table_id", f"#{tableId}", count=2)
 
     # Export the DT args to JSON
     dt_args = json.dumps(kwargs)

--- a/itables/javascript/load_datatables_connected.js
+++ b/itables/javascript/load_datatables_connected.js
@@ -1,6 +1,7 @@
-require.config({
-    paths: {
-        jquery: 'https://code.jquery.com/jquery-3.5.1.min',
-        datatables: 'https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min',
-    }
-});
+if (typeof require !== 'undefined')
+    require.config({
+        paths: {
+            jquery: 'https://code.jquery.com/jquery-3.5.1.min',
+            datatables: 'https://cdn.datatables.net/1.11.3/js/jquery.dataTables.min',
+        }
+    });


### PR DESCRIPTION
Many thanks to @fwouts for his precious help on this!

Fixes #3, #4, #26, #40