### PR TITLE
WIP: Load datatables with an ES import

### DIFF
--- a/itables/datatables_template.html
+++ b/itables/datatables_template.html
@@ -14,9 +14,9 @@
 
     // Import the DataTables library
     import $ from "https://esm.sh/jquery@3.5.0";
-    import initDataTables from "https://esm.sh/datatables.net@1.11.3?deps=jquery@3.5.0";
+    import DataTables from 'https://nightly.datatables.net/js/jquery.dataTables.mjs';
 
-    initDataTables();
+    DataTables($);
 
     // Define the dt_args (some functions might use $)
     let dt_args = {};

--- a/itables/datatables_template.html
+++ b/itables/datatables_template.html
@@ -12,35 +12,18 @@
     // Define the table data
     const data = [];
 
-    if (typeof require === 'undefined') {
-        // TODO: This should become the default (use a simple import)
-        // when the ESM version works independently of whether
-        // require.js is there or not, see
-        // https://datatables.net/forums/discussion/69066/esm-es6-module-support?
-        const {default: $} = await import("https://esm.sh/jquery@3.5.0");
-        const {default: initDataTables} = await import("https://esm.sh/datatables.net@1.11.3?deps=jquery@3.5.0");
+    // Import the DataTables library
+    import $ from "https://esm.sh/jquery@3.5.0";
+    import initDataTables from "https://esm.sh/datatables.net@1.11.3?deps=jquery@3.5.0";
 
-        initDataTables();
+    initDataTables();
 
-        // Define the dt_args
-        let dt_args = {};
-        dt_args["data"] = data;
+    // Define the dt_args (some functions might use $)
+    let dt_args = {};
+    dt_args["data"] = data;
 
-        // Display the table
-        $(document).ready(function () {
-            $('#table_id').DataTable(dt_args);
-        });
-    } else {
-        require(["jquery", "datatables"], ($, datatables) => {
-                // Define the dt_args
-                let dt_args = {};
-                dt_args["data"] = data;
-
-                // Display the table
-                $(document).ready(function () {
-                    $('#table_id').DataTable(dt_args);
-                });
-            }
-        )
-    }
+    // Display the table
+    $(document).ready(function () {
+        $('#table_id').DataTable(dt_args);
+    });
 </script>

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -160,7 +160,7 @@ def _datatables_repr_(df=None, tableId=None, **kwargs):
         '<table id="table_id"><thead><tr><th>A</th></tr></thead></table>',
         table_header,
     )
-    output = replace_value(output, "#table_id", f"#{tableId}", count=2)
+    output = replace_value(output, "#table_id", f"#{tableId}")
 
     # Export the DT args to JSON
     if eval_functions:
@@ -174,9 +174,7 @@ def _datatables_repr_(df=None, tableId=None, **kwargs):
                 "To silence this warning, use 'eval_functions=False'."
             )
 
-    output = replace_value(
-        output, "let dt_args = {};", f"let dt_args = {dt_args};", count=2
-    )
+    output = replace_value(output, "let dt_args = {};", f"let dt_args = {dt_args};")
 
     # Export the table data to JSON and include this in the HTML
     data = _formatted_values(df.reset_index() if showIndex else df)


### PR DESCRIPTION
In this PR we switch to a pure ES import of datatables, cf. https://github.com/DataTables/DataTablesSrc/issues/199

Closes #51

What remains:
- [X] Test `itables` in Jupyter Notebook
- [X] Test `itables` in Jupyter Lab
- [ ] Load `jQuery` from a more classical CDN than `https://ems.sh`
- [ ] Load `DataTables` from a safer CDN than `https://nightly.datatables.net`
- [ ] Use SRI on both imports (maybe start at https://stackoverflow.com/questions/52636690/subresource-integrity-for-es6-import-or-worker)