### PR TITLE
Improve multiindex columns

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ Changed
 -------
 - We have removed the default column width at 70 pixels (#62)
 
+Fixed
+-------
+- We have improved the rendering of multiindex columns (#63)
+
 
 0.4.5 (2022-01-25)
 ==================

--- a/environment.yml
+++ b/environment.yml
@@ -7,8 +7,10 @@ dependencies:
   - jupyter
   - jupyterlab
   - jupytext
+  - markdown-it-py>=2.0
   - nbconvert
   - ipykernel
+  - pandas
   - pytest
   - pytest-xdist
   - pytest-cov
@@ -20,7 +22,7 @@ dependencies:
   - pip
   - setuptools
   - twine
-  - jupyter-book
   - ghp-import
   - pip:
     - world_bank_data
+    - jupyter_book>=0.12  # jupyter-book-0.12.2-pyhd8ed1ab_0 requires jupytext >=1.11.2,<1.12

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -2,6 +2,7 @@
 
 import json
 import logging
+import re
 import uuid
 import warnings
 
@@ -64,12 +65,12 @@ def _formatted_values(df):
 
 def _table_header(df, table_id, show_index, classes, style):
     """This function returns the HTML table header. Rows are not included."""
-    thead = ""
-    if show_index:
-        thead = "<th></th>" * len(df.index.names)
-
-    for column in df.columns:
-        thead += f"<th>{column}</th>"
+    # Generate table head using pandas.to_html(), see issue 63
+    pattern = re.compile(r".*<thead>(.*)</thead>", flags=re.MULTILINE | re.DOTALL)
+    match = pattern.match(df.head(0).to_html())
+    thead = match.groups()[0]
+    if not show_index:
+        thead = thead.replace("<th></th>", "", 1)
 
     loading = "<td>Loading... (need <a href=https://mwouts.github.io/itables/troubleshooting.html>help</a>?)</td>"
     tbody = f"<tr>{loading}</tr>"


### PR DESCRIPTION
We use `pandas.to_html` to generate the table header, as we did in versions < 0.4.2.
This improves the rendering of tables with multiindex columns #63 