### PR TITLE
solve bug caused by df with duplicated columns name

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.1.3 (2022-08-11)
+------------------
+
+**Fixed**
+- Tables with duplicate column names are now supported, thanks to Antonio Commisso's fix ([#89](https://github.com/mwouts/jupytext/issues/89))
+
+
 1.1.2 (2022-06-30)
 ------------------
 

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -104,19 +104,21 @@ def init_notebook_mode(
 def _formatted_values(df):
     """Return the table content as a list of lists for DataTables"""
     formatted_df = df.copy()
-    for col in range(len(formatted_df.columns)):
-        x = formatted_df.iloc[:, col]
+    # We iterate over columns using an index rather than the column name
+    # to avoid an issue in case of duplicate column names #89
+    for j, col in enumerate(formatted_df):
+        x = formatted_df.iloc[:, j]
         if x.dtype.kind in ["b", "i", "s"]:
             continue
 
         if x.dtype.kind == "O":
-            formatted_df.iloc[:, col] = formatted_df.iloc[:, col].astype(str)
+            formatted_df.iloc[:, j] = formatted_df.iloc[:, j].astype(str)
             continue
 
-        formatted_df.iloc[:, col] = np.array(fmt.format_array(x.values, None))
+        formatted_df.iloc[:, j] = np.array(fmt.format_array(x.values, None))
         if x.dtype.kind == "f":
             try:
-                formatted_df.iloc[:, col] = formatted_df.iloc[:, col].astype(float)
+                formatted_df.iloc[:, j] = formatted_df.iloc[:, j].astype(float)
             except ValueError:
                 pass
 

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -105,18 +105,18 @@ def _formatted_values(df):
     """Return the table content as a list of lists for DataTables"""
     formatted_df = df.copy()
     for col in range(len(formatted_df.columns)):
-        x = formatted_df.iloc[:,col]
+        x = formatted_df.iloc[:, col]
         if x.dtype.kind in ["b", "i", "s"]:
             continue
 
         if x.dtype.kind == "O":
-            formatted_df.iloc[:,col] = formatted_df.iloc[:,col].astype(str)
+            formatted_df.iloc[:, col] = formatted_df.iloc[:, col].astype(str)
             continue
 
-        formatted_df.iloc[:,col] = np.array(fmt.format_array(x.values, None))
+        formatted_df.iloc[:, col] = np.array(fmt.format_array(x.values, None))
         if x.dtype.kind == "f":
             try:
-                formatted_df.iloc[:,col] = formatted_df.iloc[:,col].astype(float)
+                formatted_df.iloc[:, col] = formatted_df.iloc[:, col].astype(float)
             except ValueError:
                 pass
 

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -104,19 +104,19 @@ def init_notebook_mode(
 def _formatted_values(df):
     """Return the table content as a list of lists for DataTables"""
     formatted_df = df.copy()
-    for col in formatted_df:
-        x = formatted_df[col]
+    for col in range(len(formatted_df.columns)):
+        x = formatted_df.iloc[:,col]
         if x.dtype.kind in ["b", "i", "s"]:
             continue
 
         if x.dtype.kind == "O":
-            formatted_df[col] = formatted_df[col].astype(str)
+            formatted_df.iloc[:,col] = formatted_df.iloc[:,col].astype(str)
             continue
 
-        formatted_df[col] = np.array(fmt.format_array(x.values, None))
+        formatted_df.iloc[:,col] = np.array(fmt.format_array(x.values, None))
         if x.dtype.kind == "f":
             try:
-                formatted_df[col] = formatted_df[col].astype(float)
+                formatted_df.iloc[:,col] = formatted_df.iloc[:,col].astype(float)
             except ValueError:
                 pass
 

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.1.2"
+__version__ = "1.1.3"

--- a/tests/test_sample_dfs.py
+++ b/tests/test_sample_dfs.py
@@ -1,3 +1,4 @@
+import pandas as pd
 import pytest
 
 from itables import show
@@ -39,3 +40,9 @@ def test_show_test_dfs(df_name, df):
 @pytest.mark.parametrize("series_name,series", get_dict_of_test_series().items())
 def test_show_test_series(series_name, series):
     show(series)
+
+
+def test_show_df_with_duplicate_column_names():
+    df = pd.DataFrame({"a": [0], "b": [0.0], "c": ["str"]})
+    df.columns = ["duplicated_name"] * 3
+    show(df)


### PR DESCRIPTION
In my project i use sql statements in order to obtain pandas dataframes. In one queries I selected two columns with the same name from different tables and I got this error:

<img width="1353" alt="Screenshot 2022-08-10 at 18 12 17" src="https://user-images.githubusercontent.com/37751216/183961540-a1390f97-de1a-45b7-a143-7982fd1bceeb.png">

I changed the indexing method to avoid this kind of behaviour caused by pandas. 