### PR TITLE
fix: :pushpin: Change from gitlab to GitHub

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -11,7 +11,7 @@ repos:
     - id: end-of-file-fixer
     - id: trailing-whitespace
 
-  - repo: https://gitlab.com/pycqa/flake8
+  - repo: https://github.com/pycqa/flake8
     rev: 3.9.2
     hooks:
     - id: flake8


### PR DESCRIPTION
Change from GitLab to GitHub for flake8 dependency in `pre-commit`

Fixes: #124 