### PR TITLE
Display just the table (no search box, no summary) when the table only has a few rows

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2019-2022 Marc Wouts
+Copyright (c) 2019-2023 Marc Wouts
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/advanced_parameters.md
+++ b/docs/advanced_parameters.md
@@ -122,7 +122,7 @@ opt.lengthMenu = [5, 10, 20, 50, 100, 200, 500]
 
 ## Removing the search box
 
-By default, datatables comes with a search box, a pagination control, a table summary, etc.
+By default, datatables that don't fit in one page come with a search box, a pagination control, a table summary, etc.
 You can select which elements are actually displayed using
 DataTables' [`dom` option](https://datatables.net/reference/option/dom) with e.g.:
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.4.3 (2023-01-14)
+------------------
+
+**Changed**
+- When a table is made of only a few rows, we display just the table (not the search box, pagination control, etc)
+
+
 1.4.2 (2022-12-23)
 ------------------
 

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -225,6 +225,11 @@ def to_html_datatable(df=None, caption=None, tableId=None, connected=True, **kwa
     css = kwargs.pop("css")
     tags = kwargs.pop("tags")
 
+    # Only display the table if the rows fit on one 'page'
+    if "dom" not in kwargs and len(df) <= 10:  # the default page has 10 rows
+        if "lengthMenu" not in kwargs or len(df) <= min(kwargs["lengthMenu"]):
+            kwargs["dom"] = "t"
+
     if caption is not None:
         tags = '{}<caption style="white-space: nowrap; overflow: hidden">{}</caption>'.format(
             tags, caption

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.4.2"
+__version__ = "1.4.3"


### PR DESCRIPTION
If the table fits in one page (e.g. not more than 10 rows), the search box and summary take room in the output cell but are not really useful.

After this PR, only the table will be displayed when all the conditions below are satisfied:
- the table has not more than 10 rows
- the user has not set a `dom` option
- they have not set a `lengthMenu` option, or the table rows fit in the minimum length of the menu