### PR TITLE
Fix the rendering of empty Polars DataFrames

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.5.1 (2023-03-12)
+------------------
+
+**Fixed**
+- Empty Polars DataFrame are now rendered correctly ([#167](https://github.com/mwouts/itables/issues/167))
+
+
 1.5.0 (2023-03-11)
 ------------------
 

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -12,7 +12,7 @@ kernelspec:
   name: itables
 ---
 
-# Interactive Tables
+# Quick Start
 
 ![CI](https://github.com/mwouts/itables/workflows/CI/badge.svg)
 [![codecov.io](https://codecov.io/github/mwouts/itables/coverage.svg?branch=main)](https://codecov.io/github/mwouts/itables?branch=main)

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -126,6 +126,9 @@ def _table_header(
     except AttributeError:
         # Polars DataFrames
         html_header = pd.DataFrame(data=[], columns=df.columns).to_html()
+        # Don't remove the index header for empty dfs
+        if not len(df.columns):
+            show_index = True
     match = pattern.match(html_header)
     thead = match.groups()[0]
     if not show_index:

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.5.0"
+__version__ = "1.5.1"


### PR DESCRIPTION
Small fix to fix the rendering of empty Polars DataFrames.

Before:
_table loading_

Now:
![image](https://user-images.githubusercontent.com/29915202/224517500-cd1dc172-bc35-4134-87f0-d060ef1ebdb0.png)
