### PR TITLE
Test itables against pandas pre-release

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -70,6 +70,35 @@ jobs:
       - name: Upload coverage
         uses: codecov/codecov-action@v1
 
+  test-pip-pandas-pre:
+    needs: skip_duplicate
+    if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}
+    strategy:
+      matrix:
+        python-version: [ "3.11"]
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+      - name: Set up Python ${{ matrix.python-version }}
+        uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install pandas --pre
+          pip install -r requirements.txt
+          pip install -r requirements-dev.txt
+      - name: Install a development version of 'itables'
+        run: pip install -e .
+      - name: Install a Jupyter Kernel
+        run: python -m ipykernel install --name itables --user
+      - name: Test with pytest
+        run: pytest --cov=./ --cov-report=xml
+      - name: Upload coverage
+        uses: codecov/codecov-action@v1
+
   test-pip-polars:
     needs: skip_duplicate
     if: ${{ needs.skip_duplicate.outputs.should_skip == 'false' }}

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,9 +1,9 @@
 codecov:
     notify:
-        after_n_builds: 14
+        after_n_builds: 15
 
 comment:
-  after_n_builds: 14
+  after_n_builds: 15
 
 coverage:
   status:

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.5.2 (2023-03-??)
+------------------
+
+**Added**
+- We have added a CI configuration where we test `itables` against `pandas` in pre-release versions
+
+
 1.5.1 (2023-03-12)
 ------------------
 

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.5.1"
+__version__ = "1.5.2-dev"


### PR DESCRIPTION
I see that `pandas==2.0` is coming, cf. https://twitter.com/pandas_dev/status/1636497983578447872.

With this PR I am adding a CI configuration in which we run the Python tests against the latest pre-release version of `pandas`.