### PR TITLE
Remove codecov from requirements-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -4,7 +4,6 @@ isort
 flake8
 pytest
 pytest-cov
-codecov
 jupytext
 nbconvert
 jupyter_client


### PR DESCRIPTION
The CI failed at https://github.com/mwouts/itables/actions/runs/4688512497, saying that it could not find a version of `codecov` compatible with the other requirements.

Actually we don't use the `codecov` package - we use the GitHub action instead, so I will remove the package from the dev requirements.