### PR TITLE
Skip timedeltas in the sample dataframes as they fail with pandas==2.1

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.6.0-dev (2023-09-??)
+------------------
+
+**Fixed**
+- We do not generate timedeltas in the sample dataframes when using `pandas==2.1` as this fails ([pandas-#55080](https://github.com/pandas-dev/pandas/issues/55080))
+
+
 1.5.4 (2023-08-18)
 ------------------
 

--- a/itables/sample_dfs.py
+++ b/itables/sample_dfs.py
@@ -32,9 +32,14 @@ COLUMN_TYPES = [
     "timedelta",
 ]
 
-PANDAS_VERSION_MAJOR = int(pd.__version__.split(".", 1)[0])
+PANDAS_VERSION_MAJOR, PANDAS_VERSION_MINOR, _ = pd.__version__.split(".", 2)
+PANDAS_VERSION_MAJOR = int(PANDAS_VERSION_MAJOR)
+PANDAS_VERSION_MINOR = int(PANDAS_VERSION_MINOR)
 if PANDAS_VERSION_MAJOR == 0:
     COLUMN_TYPES = [type for type in COLUMN_TYPES if type != "boolean"]
+if PANDAS_VERSION_MAJOR == 2 and PANDAS_VERSION_MINOR == 1:
+    # https://github.com/pandas-dev/pandas/issues/55080
+    COLUMN_TYPES = [type for type in COLUMN_TYPES if type != "timedelta"]
 
 
 def get_countries(html=True):

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.5.4"
+__version__ = "1.6.0+dev"


### PR DESCRIPTION
Cf. https://github.com/pandas-dev/pandas/issues/55080