### PR TITLE
Fix style in Colab

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+1.6.1 (2023-10-01)
+------------------
+
+**Fixed**
+- We have fixed an issue when using Pandas style in the connected mode.
+
+
 1.6.0 (2023-09-30)
 ------------------
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,7 @@ ITables ChangeLog
 ------------------
 
 **Fixed**
-- We have fixed an issue when using Pandas style in the connected mode.
+- We have fixed an issue when rendering Pandas style objects in Google Colab ([#199](https://github.com/mwouts/itables/issues/199))
 
 
 1.6.0 (2023-09-30)

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -228,13 +228,11 @@ def replace_value(template, pattern, value):
         assert isinstance(template, str)
     count = template.count(pattern)
     if not count:
-        raise ValueError(
-            "pattern={} was not found in template={}".format(pattern, template)
-        )
+        raise ValueError("pattern={} was not found in template".format(pattern))
     elif count > 1:
         raise ValueError(
-            "pattern={} was found multiple times ({}) in template={}".format(
-                pattern, count, template
+            "pattern={} was found multiple times ({}) in template".format(
+                pattern, count
             )
         )
     return template.replace(pattern, value)

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -226,7 +226,17 @@ def replace_value(template, pattern, value):
     after making sure that the pattern is found exactly once."""
     if sys.version_info >= (3,):
         assert isinstance(template, str)
-    assert template.count(pattern) == 1
+    count = template.count(pattern)
+    if not count:
+        raise ValueError(
+            "pattern={} was not found in template={}".format(pattern, template)
+        )
+    elif count > 1:
+        raise ValueError(
+            "pattern={} was found multiple times ({}) in template={}".format(
+                pattern, count, template
+            )
+        )
     return template.replace(pattern, value)
 
 
@@ -606,5 +616,6 @@ def safe_reset_index(df):
 
 def show(df=None, caption=None, **kwargs):
     """Show a dataframe"""
-    html = to_html_datatable(df, caption=caption, connected=_CONNECTED, **kwargs)
+    connected = kwargs.pop("connected", _CONNECTED)
+    html = to_html_datatable(df, caption=caption, connected=connected, **kwargs)
     display(HTML(html))

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -457,13 +457,22 @@ def to_html_datatable_using_to_html(
         else:
             style = ""
 
-        html_table = df.to_html(
-            table_uuid=tableId,
-            table_attributes="""class="{classes}"{style}""".format(
-                classes=classes, style=style
-            ),
-            caption=caption,
-        )
+        try:
+            to_html_args = dict(
+                table_uuid=tableId,
+                table_attributes="""class="{classes}"{style}""".format(
+                    classes=classes, style=style
+                ),
+                caption=caption,
+            )
+            html_table = df.to_html(**to_html_args)
+        except TypeError:
+            if caption is not None:
+                warnings.warn(
+                    "caption is not supported by Styler.to_html in your version of Pandas"
+                )
+            del to_html_args["caption"]
+            html_table = df.to_html(**to_html_args)
         tableId = "T_" + tableId
     else:
         if caption is not None:

--- a/itables/version.py
+++ b/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "1.6.0"
+__version__ = "1.6.1"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,7 +1,7 @@
 import pandas as pd
 import pytest
 
-from itables.sample_dfs import get_dict_of_test_dfs
+from itables.sample_dfs import PANDAS_VERSION_MAJOR, get_dict_of_test_dfs
 
 
 @pytest.fixture(params=list(get_dict_of_test_dfs()))
@@ -26,6 +26,6 @@ def connected(request):
     return request.param
 
 
-@pytest.fixture(params=[False, True])
+@pytest.fixture(params=[False, True] if PANDAS_VERSION_MAJOR >= 1 else [False])
 def use_to_html(request):
     return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -24,3 +24,8 @@ def lengthMenu(request):
 @pytest.fixture(params=[False, True])
 def connected(request):
     return request.param
+
+
+@pytest.fixture(params=[False, True])
+def use_to_html(request):
+    return request.param

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -19,3 +19,8 @@ def lengthMenu(request):
     if request.param == "2D-array":
         return [[10, 25, 50, 100, -1], [10, 25, 50, 100, "All"]]
     return None
+
+
+@pytest.fixture(params=[False, True])
+def connected(request):
+    return request.param

--- a/tests/test_javascript.py
+++ b/tests/test_javascript.py
@@ -1,4 +1,26 @@
-from itables.javascript import _df_fits_in_one_page, to_html_datatable
+import pytest
+
+from itables.javascript import _df_fits_in_one_page, replace_value, to_html_datatable
+
+
+def test_replace_value(
+    template="line1\nline2\nline3\n", pattern="line2", value="new line2"
+):
+    assert replace_value(template, pattern, value) == "line1\nnew line2\nline3\n"
+
+
+def test_replace_value_not_found(
+    template="line1\nline2\nline3\n", pattern="line4", value="new line4"
+):
+    with pytest.raises(ValueError, match="not found"):
+        assert replace_value(template, pattern, value)
+
+
+def test_replace_value_multiple(
+    template="line1\nline2\nline2\n", pattern="line2", value="new line2"
+):
+    with pytest.raises(ValueError, match="found multiple times"):
+        assert replace_value(template, pattern, value)
 
 
 def test_warn_on_unexpected_types_not_in_html(df):

--- a/tests/test_json_dumps.py
+++ b/tests/test_json_dumps.py
@@ -27,19 +27,19 @@ def coloredColumnDefs():
     ]
 
 
-def test_warning_when_eval_functions_is_missing(df, coloredColumnDefs):
+def test_warning_when_eval_functions_is_missing(df, coloredColumnDefs, connected):
     with pytest.warns(UserWarning, match="starts with 'function'"):
-        show(df, columnDefs=coloredColumnDefs)
+        show(df, connected=connected, columnDefs=coloredColumnDefs)
 
 
-def test_no_warning_when_eval_functions_is_false(df, coloredColumnDefs):
+def test_no_warning_when_eval_functions_is_false(df, coloredColumnDefs, connected):
     warnings.simplefilter("error")
-    show(df, columnDefs=coloredColumnDefs, eval_functions=False)
+    show(df, connected=connected, columnDefs=coloredColumnDefs, eval_functions=False)
 
 
-def test_no_warning_when_eval_functions_is_true(df, coloredColumnDefs):
+def test_no_warning_when_eval_functions_is_true(df, coloredColumnDefs, connected):
     warnings.simplefilter("error")
-    show(df, columnDefs=coloredColumnDefs, eval_functions=True)
+    show(df, connected=connected, columnDefs=coloredColumnDefs, eval_functions=True)
 
 
 @pytest.mark.parametrize("obj", ["a", 1, 1.0, [1.0, "a", {"a": [0, 1]}]])

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -12,12 +12,12 @@ except ImportError as e:
 @pytest.mark.parametrize(
     "name,x", [(name, x) for name, x in get_dict_of_test_series(polars=True).items()]
 )
-def test_show_polars_series(name, x):
-    to_html_datatable(x)
+def test_show_polars_series(name, x, use_to_html):
+    to_html_datatable(x, use_to_html)
 
 
 @pytest.mark.parametrize(
     "name,df", [(name, df) for name, df in get_dict_of_test_dfs(polars=True).items()]
 )
-def test_show_polars_df(name, df):
-    to_html_datatable(df)
+def test_show_polars_df(name, df, use_to_html):
+    to_html_datatable(df, use_to_html)

--- a/tests/test_sample_dfs.py
+++ b/tests/test_sample_dfs.py
@@ -32,52 +32,60 @@ if PANDAS_VERSION_MAJOR < 2:
     pytestmark.append(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
 
 
-def test_get_countries(connected):
+def test_get_countries(connected, use_to_html):
     df = get_countries()
     assert len(df.columns) > 5
     assert len(df.index) > 100
-    show(df, connected=connected)
+    show(df, connected=connected, use_to_html=use_to_html)
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="fails in Py2")
-def test_get_population(connected):
+def test_get_population(connected, use_to_html):
     x = get_population()
     assert len(x) > 30
     assert x.max() > 7e9
-    show(x, connected=connected)
+    show(x, connected=connected, use_to_html=use_to_html)
 
 
-def test_get_indicators(connected):
+def test_get_indicators(connected, use_to_html):
     df = get_indicators()
     assert len(df.index) == 500
     assert len(df.columns)
-    show(df, connected=connected)
+    show(df, connected=connected, use_to_html=use_to_html)
 
 
 @pytest.mark.skipif(
     sys.version_info < (3, 7),
     reason="AttributeError: 'Styler' object has no attribute 'to_html'",
 )
-def test_get_pandas_styler(connected):
+def test_get_pandas_styler(connected, use_to_html):
     styler = get_pandas_styler()
-    show(styler, connected=connected)
+    show(styler, connected=connected, use_to_html=use_to_html)
 
 
 def kwargs_remove_none(**kwargs):
     return {key: value for key, value in kwargs.items() if value is not None}
 
 
-def test_show_test_dfs(df, connected, lengthMenu, monkeypatch):
+def test_show_test_dfs(df, connected, use_to_html, lengthMenu, monkeypatch):
     if "bigint" in df.columns:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
-    show(df, connected=connected, **kwargs_remove_none(lengthMenu=lengthMenu))
+    show(
+        df,
+        connected=connected,
+        use_to_html=use_to_html,
+        **kwargs_remove_none(lengthMenu=lengthMenu)
+    )
 
 
-def test_to_html_datatable(df, connected, lengthMenu, monkeypatch):
+def test_to_html_datatable(df, connected, use_to_html, lengthMenu, monkeypatch):
     if "bigint" in df.columns:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
     to_html_datatable(
-        df, connected=connected, **kwargs_remove_none(lengthMenu=lengthMenu)
+        df,
+        connected=connected,
+        use_to_html=use_to_html,
+        **kwargs_remove_none(lengthMenu=lengthMenu)
     )
 
 
@@ -94,16 +102,16 @@ def test_format_column(series_name, series):
 
 
 @pytest.mark.parametrize("series_name,series", get_dict_of_test_series().items())
-def test_show_test_series(series_name, series, connected, monkeypatch):
+def test_show_test_series(series_name, series, connected, use_to_html, monkeypatch):
     if "bigint" in series_name:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
-    show(series, connected=connected)
+    show(series, connected=connected, use_to_html=use_to_html)
 
 
-def test_show_df_with_duplicate_column_names(connected):
+def test_show_df_with_duplicate_column_names(connected, use_to_html):
     df = pd.DataFrame({"a": [0], "b": [0.0], "c": ["str"]})
     df.columns = ["duplicated_name"] * 3
-    show(df, connected=connected)
+    show(df, connected=connected, use_to_html=use_to_html)
 
 
 @pytest.mark.parametrize("type", COLUMN_TYPES)

--- a/tests/test_sample_dfs.py
+++ b/tests/test_sample_dfs.py
@@ -32,51 +32,53 @@ if PANDAS_VERSION_MAJOR < 2:
     pytestmark.append(pytest.mark.filterwarnings("ignore::DeprecationWarning"))
 
 
-def test_get_countries():
+def test_get_countries(connected):
     df = get_countries()
     assert len(df.columns) > 5
     assert len(df.index) > 100
-    show(df)
+    show(df, connected=connected)
 
 
 @pytest.mark.skipif(sys.version_info < (3,), reason="fails in Py2")
-def test_get_population():
+def test_get_population(connected):
     x = get_population()
     assert len(x) > 30
     assert x.max() > 7e9
-    show(x)
+    show(x, connected=connected)
 
 
-def test_get_indicators():
+def test_get_indicators(connected):
     df = get_indicators()
     assert len(df.index) == 500
     assert len(df.columns)
-    show(df)
+    show(df, connected=connected)
 
 
 @pytest.mark.skipif(
     sys.version_info < (3, 7),
     reason="AttributeError: 'Styler' object has no attribute 'to_html'",
 )
-def test_get_pandas_styler():
+def test_get_pandas_styler(connected):
     styler = get_pandas_styler()
-    show(styler)
+    show(styler, connected=connected)
 
 
 def kwargs_remove_none(**kwargs):
     return {key: value for key, value in kwargs.items() if value is not None}
 
 
-def test_show_test_dfs(df, lengthMenu, monkeypatch):
+def test_show_test_dfs(df, connected, lengthMenu, monkeypatch):
     if "bigint" in df.columns:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
-    show(df, **kwargs_remove_none(lengthMenu=lengthMenu))
+    show(df, connected=connected, **kwargs_remove_none(lengthMenu=lengthMenu))
 
 
-def test_to_html_datatable(df, lengthMenu, monkeypatch):
+def test_to_html_datatable(df, connected, lengthMenu, monkeypatch):
     if "bigint" in df.columns:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
-    to_html_datatable(df, **kwargs_remove_none(lengthMenu=lengthMenu))
+    to_html_datatable(
+        df, connected=connected, **kwargs_remove_none(lengthMenu=lengthMenu)
+    )
 
 
 def test_ordered_categories():
@@ -92,16 +94,16 @@ def test_format_column(series_name, series):
 
 
 @pytest.mark.parametrize("series_name,series", get_dict_of_test_series().items())
-def test_show_test_series(series_name, series, monkeypatch):
+def test_show_test_series(series_name, series, connected, monkeypatch):
     if "bigint" in series_name:
         monkeypatch.setattr("itables.options.warn_on_int_to_str_conversion", False)
-    show(series)
+    show(series, connected=connected)
 
 
-def test_show_df_with_duplicate_column_names():
+def test_show_df_with_duplicate_column_names(connected):
     df = pd.DataFrame({"a": [0], "b": [0.0], "c": ["str"]})
     df.columns = ["duplicated_name"] * 3
-    show(df)
+    show(df, connected=connected)
 
 
 @pytest.mark.parametrize("type", COLUMN_TYPES)


### PR DESCRIPTION
In this PR we pass the `table_attributes` and `caption` directly to the `to_html` method.
This way we don't need to parse/modify the HTML generated by Styler.to_html.

Closes #199 