### PR TITLE
Create optional dependency groups and install them on Binder

### DIFF
--- a/binder/postBuild
+++ b/binder/postBuild
@@ -2,7 +2,7 @@
 set -e
 
 # Install from sources
-pip install .
+pip install .[all]
 
 # Open .md notebooks with the Notebook editor
 mkdir -p ${HOME}/.jupyter/labconfig

--- a/docs/advanced_parameters.md
+++ b/docs/advanced_parameters.md
@@ -12,7 +12,7 @@ kernelspec:
   name: itables
 ---
 
-# The DataTable Arguments
+# The DataTables Arguments
 
 ITables is a wrapper for the Javascript [DataTables](https://datatables.net/) library, which has a great [documentation](https://datatables.net/), a huge collection of [examples](https://datatables.net/examples/index), and a useful [forum](https://datatables.net/forums/).
 

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -71,7 +71,7 @@ show(
 
 You can use Javascript callbacks to set the cell or row style depending on the cell content.
 
-The example below, in which we color in red the cells with negative numbers, is directly inspired by the corresponding datatables.net [example](https://datatables.net/reference/option/columns.createdCell).
+The example below, in which we color in red the cells with negative numbers, is directly inspired by the corresponding DataTables [example](https://datatables.net/reference/option/columns.createdCell).
 
 Note how the Javascript callback is declared as `JavascriptFunction` object below.
 

--- a/docs/pandas_style.md
+++ b/docs/pandas_style.md
@@ -86,7 +86,7 @@ s.set_tooltips(ttips).set_caption("With tooltips")
 
 ```{note}
 Unlike Pandas or Polar DataFrames, `Styler` objects are rendered directly using their
-`to_html` method, rather than passing the underlying table data to the datatables.net
+`to_html` method, rather than passing the underlying table data to the DataTables
 library.
 
 Because of this, the rendering of the table might differ slightly from the rendering of the

--- a/itables/javascript.py
+++ b/itables/javascript.py
@@ -156,7 +156,7 @@ def _table_header(
         html_header = df.head(0).to_html(escape=False)
     except AttributeError:
         # Polars DataFrames
-        html_header = pd.DataFrame(data=[], columns=df.columns).to_html()
+        html_header = pd.DataFrame(data=[], columns=df.columns, dtype=float).to_html()
     match = pattern.match(html_header)
     thead = match.groups()[0]
     # Don't remove the index header for empty dfs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,6 +8,7 @@ authors = [{name = "Marc Wouts", email = "marc.wouts@gmail.com"}]
 maintainers = [{name = "Marc Wouts", email = "marc.wouts@gmail.com"}]
 description = "Pandas and Polar DataFrames as interactive DataTables"
 readme = "README.md"
+license = { file = "LICENSE" }
 keywords = ["Pandas", "Polars", "Interactive", "Javascript", "DataTables"]
 classifiers = [
   "Development Status :: 5 - Production/Stable",
@@ -28,27 +29,26 @@ requires-python = ">= 3.7"
 dependencies = ["IPython", "pandas", "numpy"]
 dynamic = ["version"]
 
-[tool.hatch.version]
-path = "itables/version.py"
-
 [project.optional-dependencies]
+polars = ["polars", "pyarrow"]
+style = ["matplotlib"]
+samples = ["pytz", "world_bank_data"]
+all = ["itables[polars,style,samples]"]
 test = [
+  "itables[all]",
   # Pytest
   "pytest",
   "pytest-cov",
-  # Sample dfs
-  "pytz",
-  "world_bank_data",
   # Test the documentation
   "ipykernel",
   "nbconvert",
   "jupytext",
-  # Pandas style
-  "matplotlib",
   # Shiny test app
   "shiny"
 ]
-polars = ["polars", "pyarrow"]
+
+[tool.hatch.version]
+path = "itables/version.py"
 
 [project.urls]
 Homepage = "https://mwouts.github.io/itables/"


### PR DESCRIPTION
We need all the optional dependencies on Binders to make sure that the docs are correctly executed when rendered there.