### PR TITLE
Add column choice to searchPanes example

### DIFF
--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -121,7 +121,7 @@ argument is required (otherwise the search panes are too wide).
 show(
     df,
     layout={"top1": "searchPanes"},
-    searchPanes={"layout": "columns-3", "cascadePanes": True},
+    searchPanes={"layout": "columns-3", "cascadePanes": True, 'columns': [1, 6, 7]},
 )
 ```
 

--- a/docs/extensions.md
+++ b/docs/extensions.md
@@ -121,7 +121,7 @@ argument is required (otherwise the search panes are too wide).
 show(
     df,
     layout={"top1": "searchPanes"},
-    searchPanes={"layout": "columns-3", "cascadePanes": True, 'columns': [1, 6, 7]},
+    searchPanes={"layout": "columns-3", "cascadePanes": True, "columns": [1, 6, 7]},
 )
 ```
 


### PR DESCRIPTION
I think it is useful to demonstrate how to choose which columns to use for the search pane, which is done by adding the a "columns" entry to the searchPanes dictionary.