### PR TITLE
Explicit encoding argument in read_text()

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ ITables ChangeLog
 ------------------
 
 **Fixed**
+- We have added an explicit `encoding` argument in the calls to `read_text` to address an issue seen on Windows ([#252](https://github.com/mwouts/itables/issues/252)).
 - We have adjusted the codecov settings ([#280](https://github.com/mwouts/itables/pull/280))
 
 

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -128,8 +128,8 @@ def get_animated_logo(display_logo_when_loading):
 
 def generate_init_offline_itables_html(dt_bundle: Path):
     assert dt_bundle.suffix == ".js"
-    dt_src = dt_bundle.read_text()
-    dt_css = dt_bundle.with_suffix(".css").read_text()
+    dt_src = dt_bundle.read_text(encoding="utf-8")
+    dt_css = dt_bundle.with_suffix(".css").read_text(encoding="utf-8")
     dt64 = b64encode(dt_src.encode("utf-8")).decode("ascii")
 
     id = "itables_init_notebook_mode_" + str(uuid.uuid4()).replace("-", "_")

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "2.1.0"
+__version__ = "2.1.1-dev"


### PR DESCRIPTION
Closes #252 
Closes #285