### PR TITLE
Fix issue with tfoot not working in (Jupyter) HTML export

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,6 +5,7 @@ ITables ChangeLog
 ------------------
 
 **Fixed**
+- Table footers continue to work when the notebook is exported to HTML ([#331](https://github.com/mwouts/itables/issues/331))
 - The dependencies of the Streamlit component have been updated ([#327](https://github.com/mwouts/itables/pull/327), [#330](https://github.com/mwouts/itables/pull/330))
 
 **Added**

--- a/src/itables/html/column_filters/pre_dt_code.js
+++ b/src/itables/html/column_filters/pre_dt_code.js
@@ -1,9 +1,8 @@
 // Setup - add a text input to each header or footer cell
 $('#table_id:not(.dataTable) thead_or_tfoot th').each(function () {
-    let title = $(this).text();
-    $(this).html('<input type="text" placeholder="Search ' +
-        // We use encodeURI to avoid this LGTM error:
-        // https://lgtm.com/rules/1511866576920/
-        encodeURI(title).replaceAll("%20", " ") +
-        '" />');
+    var input = document.createElement("input");
+    input.type = "text";
+    input.placeholder = "Search " + $(this).text();
+
+    $(this).html(input);
 });

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -60,12 +60,7 @@ DEFAULT_LAYOUT_CONTROLS = set(DEFAULT_LAYOUT.values())
 
 
 try:
-    import google.colab
-
-    # I can't find out how to suppress the LGTM alert about unused-import
-    # (Tried with # lgtm[py/unused-import]  # noqa: F401)
-    # So we use the import:
-    assert google.colab.output
+    import google.colab  # noqa: F401
 
     GOOGLE_COLAB = True
 except ImportError:
@@ -200,8 +195,7 @@ Loading ITables v{itables_version} from {itables_source}...
         footer = ""
 
     return """<table id="{table_id}" class="{classes}" data-quarto-disable-processing="true" {style}>
-{tags}{header}<tbody>{tbody}</tbody>
-{footer}
+{tags}{header}{footer}<tbody>{tbody}</tbody>
 </table>""".format(
         table_id=table_id,
         classes=classes,

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "2.2.3-dev"
+__version__ = "2.2.3"


### PR DESCRIPTION
Prior to this, the table footer would go outside of the table when exporting the notebook to HTML