### PR TITLE
Mark Jupyter Notebooks as documentation

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+*.ipynb linguist-documentation


### PR DESCRIPTION
The intent is to help linguist figure out that ITables is mostly made of Python and Javascript code