### PR TITLE
WIP: Add test for Modin dataframes

### DIFF
--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -32,3 +32,4 @@ parts:
     chapters:
     - file: sample_dataframes
     - file: polars_dataframes
+    - file: modin_dataframes

--- a/docs/modin_dataframes.md
+++ b/docs/modin_dataframes.md
@@ -1,0 +1,183 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: -jupytext.text_representation.jupytext_version
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: itables
+  language: python
+  name: itables
+---
+
+# Modin DataFrames
+
+In this notebook we make sure that our test dataframes are displayed nicely with the default `itables` settings.
+
+```{code-cell}
+from itables import init_notebook_mode, show
+from itables.sample_dfs import get_dict_of_test_modin_dfs
+
+dict_of_test_dfs = get_dict_of_test_modin_dfs()
+init_notebook_mode(all_interactive=True)
+```
+
+## empty
+
+```{code-cell}
+show(dict_of_test_dfs["empty"])
+```
+
+## No rows
+
+```{code-cell}
+show(dict_of_test_dfs["no_rows"])
+```
+
+## No rows one column
+
+```{code-cell}
+show(dict_of_test_dfs["no_rows_one_column"])
+```
+
+## No columns
+
+```{code-cell}
+show(dict_of_test_dfs["no_columns"])
+```
+
+## No columns one row
+
+```{code-cell}
+show(dict_of_test_dfs["no_columns_one_row"])
+```
+
+## bool
+
+```{code-cell}
+show(dict_of_test_dfs["bool"])
+```
+
+## Nullable boolean
+
+```{code-cell}
+show(dict_of_test_dfs["nullable_boolean"])
+```
+
+## int
+
+```{code-cell}
+show(dict_of_test_dfs["int"])
+```
+
+## Nullable integer
+
+```{code-cell}
+show(dict_of_test_dfs["nullable_int"])
+```
+
+## float
+
+```{code-cell}
+show(dict_of_test_dfs["float"])
+```
+
+## str
+
+```{code-cell}
+show(dict_of_test_dfs["str"])
+```
+
+## time
+
+```{code-cell}
+show(dict_of_test_dfs["time"])
+```
+
+## object
+
+```{code-cell}
+show(dict_of_test_dfs["object"])
+```
+
+## ordered_categories
+
+```{code-cell}
+show(dict_of_test_dfs["ordered_categories"])
+```
+
+## ordered_categories_in_multiindex
+
+```{code-cell}
+show(dict_of_test_dfs["ordered_categories_in_multiindex"])
+```
+
+## multiindex
+
+```{code-cell}
+show(dict_of_test_dfs["multiindex"])
+```
+
+## countries
+
+```{code-cell}
+:tags: [full-width]
+
+show(dict_of_test_dfs["countries"])
+```
+
+## capital
+
+```{code-cell}
+show(dict_of_test_dfs["capital"])
+```
+
+## complex_index
+
+```{code-cell}
+:tags: [full-width]
+
+show(dict_of_test_dfs["complex_index"])
+```
+
+## int_float_str
+
+```{code-cell}
+show(dict_of_test_dfs["int_float_str"])
+```
+
+## wide
+
+```{code-cell}
+:tags: [full-width]
+
+show(dict_of_test_dfs["wide"], maxBytes=100000, maxColumns=100, scrollX=True)
+```
+
+## long_column_names
+
+```{code-cell}
+:tags: [full-width]
+
+show(dict_of_test_dfs["long_column_names"], scrollX=True)
+```
+
+## duplicated_columns
+
+```{code-cell}
+show(dict_of_test_dfs["duplicated_columns"])
+```
+
+## named_column_index
+
+```{code-cell}
+show(dict_of_test_dfs["named_column_index"])
+```
+
+## big_integers
+
+```{code-cell}
+show(dict_of_test_dfs["big_integers"])
+```

--- a/docs/polars_dataframes.md
+++ b/docs/polars_dataframes.md
@@ -19,9 +19,9 @@ dataframes are displayed nicely with the default `itables` settings.
 
 ```{code-cell}
 from itables import init_notebook_mode, show
-from itables.sample_dfs import get_dict_of_test_dfs
+from itables.sample_dfs import get_dict_of_test_polars_dfs
 
-dict_of_test_dfs = get_dict_of_test_dfs(polars=True)
+dict_of_test_dfs = get_dict_of_test_polars_dfs()
 init_notebook_mode(all_interactive=True)
 ```
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
   "Programming Language :: Python :: 3.13",
 ]
 requires-python = ">= 3.7"
-dependencies = ["IPython", "pandas", "numpy"]
+dependencies = ["IPython", "pandas", "numpy", "narwhals"]
 dynamic = ["version"]
 
 [project.optional-dependencies]

--- a/src/itables/datatables_format.py
+++ b/src/itables/datatables_format.py
@@ -8,12 +8,6 @@ import pandas as pd
 import pandas.io.formats.format as fmt
 from narwhals.stable.v1.dependencies import is_pandas_dataframe
 
-try:
-    import polars as pl
-except ImportError:
-    pl = None
-
-
 JS_MAX_SAFE_INTEGER = 2**53 - 1
 JS_MIN_SAFE_INTEGER = -(2**53 - 1)
 
@@ -85,6 +79,8 @@ def datatables_rows(df, count=None, warn_on_unexpected_types=False, pure_json=Fa
     """Format the values in the table and return the data, row by row, as requested by DataTables"""
     # We iterate over columns using an index rather than the column name
     # to avoid an issue in case of duplicated column names #89
+
+    # TODO: why not if isinstance(df, pd.DataFrame)
     if is_pandas_dataframe(df):
 
         if count is None or len(df.columns) == count:
@@ -112,7 +108,7 @@ def datatables_rows(df, count=None, warn_on_unexpected_types=False, pure_json=Fa
             allow_nan=not pure_json,
         )
     else:
-        # Polars DataFrame
+        # Polars, Modin, or other
         df = nw.from_native(df)
         data = list(df.iter_rows())
 

--- a/src/itables/downsample.py
+++ b/src/itables/downsample.py
@@ -2,15 +2,23 @@ import math
 
 import pandas as pd
 
-from .datatables_format import _isetitem
-
 
 def nbytes(df):
-    try:
+    if isinstance(df, pd.DataFrame):
         return sum(x.values.nbytes for _, x in df.items())
-    except AttributeError:
-        # Polars DataFrame
+
+    try:
+        # Polars
         return df.estimated_size()
+    except AttributeError:
+        # Modin
+        return df.memory_usage(deep=True).sum()
+    except AttributeError:
+        # Not tested
+        return sum(x.values.nbytes for x in df.columns)
+    except AttributeError:
+        # Modin series
+        raise df.values.nbytes
 
 
 def as_nbytes(mem):
@@ -97,30 +105,32 @@ def _downsample(df, max_rows=0, max_columns=0, max_bytes=0, target_aspect_ratio=
         second_half = max_rows // 2
         first_half = max_rows - second_half
         if second_half:
-            try:
+            if isinstance(df, pd.DataFrame):
                 df = pd.concat((df.iloc[:first_half], df.iloc[-second_half:]))
-            except AttributeError:
+            else:
+                # TODO: use narwhals for this
                 df = df.head(first_half).vstack(df.tail(second_half))
         else:
-            try:
+            if isinstance(df, pd.DataFrame):
                 df = df.iloc[:first_half]
-            except AttributeError:
+            else:
                 df = df.head(first_half)
 
     if len(df.columns) > max_columns > 0:
         second_half = max_columns // 2
         first_half = max_columns - second_half
         if second_half:
-            try:
+            if isinstance(df, pd.DataFrame):
                 df = pd.concat(
                     (df.iloc[:, :first_half], df.iloc[:, -second_half:]), axis=1
                 )
-            except AttributeError:
+            else:
+                # TODO: use narwhals for this
                 df = df[df.columns[:first_half]].hstack(df[df.columns[-second_half:]])
         else:
-            try:
+            if isinstance(df, pd.DataFrame):
                 df = df.iloc[:, :first_half]
-            except AttributeError:
+            else:
                 df = df[df.columns[:first_half]]
 
     df_nbytes = nbytes(df)
@@ -144,13 +154,6 @@ def _downsample(df, max_rows=0, max_columns=0, max_bytes=0, target_aspect_ratio=
             )
 
         # max_bytes is smaller than the average size of one cell
-        try:
-            df = df.iloc[:1, :1]
-            _isetitem(df, 0, ["..."])
-        except AttributeError:
-            import polars as pl  # noqa
-
-            df = pl.DataFrame({df.columns[0]: ["..."]})
-        return df
+        return pd.DataFrame({df.columns[0]: ["..."]})
 
     return df

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -96,6 +96,8 @@ def init_notebook_mode(
             pd_style.Styler._repr_html_ = _datatables_repr_
         pl.DataFrame._repr_html_ = _datatables_repr_
         pl.Series._repr_html_ = _datatables_repr_
+        # TODO: add support for Modin but without importing modin
+        # to avoid memory consumption issues
     else:
         pd.DataFrame._repr_html_ = _ORIGINAL_DATAFRAME_REPR_HTML
         if pd_style is not None:
@@ -156,10 +158,9 @@ def _table_header(
     """This function returns the HTML table header. Rows are not included."""
     # Generate table head using pandas.to_html(), see issue 63
     pattern = re.compile(r".*<thead>(.*)</thead>", flags=re.MULTILINE | re.DOTALL)
-    try:
+    if isinstance(df, pd.DataFrame):
         html_header = df.head(0).to_html(escape=False)
-    except AttributeError:
-        # Polars DataFrames
+    else:
         html_header = pd.DataFrame(data=[], columns=df.columns, dtype=float).to_html()
     match = pattern.match(html_header)
     thead = match.groups()[0]
@@ -344,16 +345,18 @@ def to_html_datatable(
     if isinstance(df, (np.ndarray, np.generic)):
         df = pd.DataFrame(df)
 
-    if isinstance(df, (pd.Series, pl.Series)):
+    # Converted Series (Pandas, Polars, Modin, etc...) to DataFrames
+    try:
         df = df.to_frame()
+    except AttributeError:
+        pass
 
     if showIndex == "auto":
-        try:
+        if isinstance(df, pd.DataFrame):
             showIndex = df.index.name is not None or not isinstance(
                 df.index, pd.RangeIndex
             )
-        except AttributeError:
-            # Polars DataFrame
+        else:
             showIndex = False
 
     maxBytes = kwargs.pop("maxBytes", 0)
@@ -407,11 +410,8 @@ def to_html_datatable(
         classes = " ".join(classes)
 
     if not showIndex:
-        try:
+        if isinstance(df, pd.DataFrame):
             df = df.set_index(pd.RangeIndex(len(df.index)))
-        except AttributeError:
-            # Polars DataFrames
-            pass
 
     table_header = _table_header(
         df,
@@ -512,12 +512,11 @@ def get_itables_extension_arguments(df, caption=None, selected_rows=None, **kwar
         df = df.to_frame()
 
     if showIndex == "auto":
-        try:
+        if isinstance(df, pd.DataFrame):
             showIndex = df.index.name is not None or not isinstance(
                 df.index, pd.RangeIndex
             )
-        except AttributeError:
-            # Polars DataFrame
+        else:
             showIndex = False
 
     maxBytes = kwargs.pop("maxBytes", 0)
@@ -540,12 +539,8 @@ def get_itables_extension_arguments(df, caption=None, selected_rows=None, **kwar
     if isinstance(classes, list):
         classes = " ".join(classes)
 
-    if not showIndex:
-        try:
-            df = df.set_index(pd.RangeIndex(len(df.index)))
-        except AttributeError:
-            # Polars DataFrames
-            pass
+    if not showIndex and isinstance(df, pd.DataFrame):
+        df = df.set_index(pd.RangeIndex(len(df.index)))
 
     if showIndex:
         df = safe_reset_index(df)
@@ -722,12 +717,11 @@ def to_html_datatable_using_to_html(
         df = df.to_frame()
 
     if showIndex == "auto":
-        try:
+        if isinstance(df, pd.DataFrame):
             showIndex = df.index.name is not None or not isinstance(
                 df.index, pd.RangeIndex
             )
-        except AttributeError:
-            # Polars DataFrame
+        else:
             showIndex = False
 
     _adjust_layout(
@@ -938,12 +932,9 @@ def _adjust_layout(df, kwargs, *, downsampling_warning, warn_on_dom):
 
 def _df_fits_in_one_page(df, kwargs):
     """Display just the table (not the search box, etc...) if the rows fit on one 'page'"""
-    try:
-        # Pandas DF or Style
+    if isinstance(df, (pd.DataFrame, pd.io.formats.style.Styler)):
         return len(df.index) <= _min_rows(kwargs)
-    except AttributeError:
-        # Polars
-        return len(df) <= _min_rows(kwargs)
+    return len(df) <= _min_rows(kwargs)
 
 
 def _filter_control(control, downsampling_warning):

--- a/src/itables/sample_dfs.py
+++ b/src/itables/sample_dfs.py
@@ -284,6 +284,19 @@ def get_dict_of_test_polars_dfs(**kwargs):
     return polars_dfs
 
 
+def get_dict_of_test_modin_dfs(**kwargs):
+
+    import modin.pandas as pd
+
+    modin_dfs = {}
+    for key, df in get_dict_of_test_dfs(**kwargs).items():
+        # TODO: see what we can do about those
+        if key in {"multiindex", "duplicated_columns", "complex_index"}:
+            continue
+        modin_dfs[key] = pd.DataFrame(df)
+    return modin_dfs
+
+
 def get_dict_of_test_series():
     series = {}
     for df_name, df in get_dict_of_test_dfs().items():
@@ -293,7 +306,11 @@ def get_dict_of_test_series():
             # Case of duplicate columns
             if not isinstance(df[col], pd.Series):
                 continue
-            series["{}.{}".format(df_name, col)] = df[col]
+            if isinstance(col, tuple):
+                col_name = "/".join(str(x) for x in col)
+            else:
+                col_name = str(col)
+            series[f"{df_name}.{col_name}"] = df[col]
 
     return series
 
@@ -317,6 +334,14 @@ def get_dict_of_test_polars_series():
     polars_series["u64"] = pl.Series([1, 2, 2**40]).cast(pl.UInt64)
 
     return polars_series
+
+
+def get_dict_of_test_modin_series():
+    import modin.pandas as mpd
+
+    return {
+        name: mpd.Series(value) for name, value in get_dict_of_test_series().items()
+    }
 
 
 @lru_cache()

--- a/src/itables/sample_dfs.py
+++ b/src/itables/sample_dfs.py
@@ -100,7 +100,7 @@ def get_df_complex_index():
     return df
 
 
-def get_dict_of_test_dfs(N=100, M=100, polars=False):
+def get_dict_of_test_dfs(N=100, M=100):
     NM_values = np.reshape(np.linspace(start=0.0, stop=1.0, num=N * M), (N, M))
 
     test_dfs = {
@@ -261,29 +261,30 @@ def get_dict_of_test_dfs(N=100, M=100, polars=False):
             }
         ),
     }
-
-    if polars:
-        import polars as pl
-        import pyarrow as pa
-
-        polars_dfs = {}
-        for key, df in test_dfs.items():
-            if key == "multiindex":
-                # Since Polars 1.2, pl.from_pandas fails with this error:
-                # ValueError: Pandas dataframe contains non-unique indices and/or column names.
-                # Polars dataframes require unique string names for columns.
-                # See https://github.com/pola-rs/polars/issues/18130
-                df.index = df.index.tolist()
-            try:
-                polars_dfs[key] = pl.from_pandas(df)
-            except (pa.ArrowInvalid, ValueError):
-                pass
-        return polars_dfs
-
     return test_dfs
 
 
-def get_dict_of_test_series(polars=False):
+def get_dict_of_test_polars_dfs(**kwargs):
+
+    import polars as pl
+    import pyarrow as pa
+
+    polars_dfs = {}
+    for key, df in get_dict_of_test_dfs(**kwargs).items():
+        if key == "multiindex":
+            # Since Polars 1.2, pl.from_pandas fails with this error:
+            # ValueError: Pandas dataframe contains non-unique indices and/or column names.
+            # Polars dataframes require unique string names for columns.
+            # See https://github.com/pola-rs/polars/issues/18130
+            df.index = df.index.tolist()
+        try:
+            polars_dfs[key] = pl.from_pandas(df)
+        except (pa.ArrowInvalid, ValueError):
+            pass
+    return polars_dfs
+
+
+def get_dict_of_test_series():
     series = {}
     for df_name, df in get_dict_of_test_dfs().items():
         if len(df.columns) > 6:
@@ -294,26 +295,28 @@ def get_dict_of_test_series(polars=False):
                 continue
             series["{}.{}".format(df_name, col)] = df[col]
 
-    if polars:
-        import polars as pl
-        import pyarrow as pa
-
-        polars_series = {}
-        for key in series:
-            try:
-                polars_series[key] = pl.from_pandas(series[key])
-            except (pa.ArrowInvalid, ValueError):
-                pass
-
-        # Add a Polar table with unsigned integers
-        # https://github.com/mwouts/itables/issues/192
-        # https://github.com/mwouts/itables/issues/299
-        polars_series["u32"] = pl.Series([1, 2, 5]).cast(pl.UInt32)
-        polars_series["u64"] = pl.Series([1, 2, 2**40]).cast(pl.UInt64)
-
-        return polars_series
-
     return series
+
+
+def get_dict_of_test_polars_series():
+    import polars as pl
+    import pyarrow as pa
+
+    series = get_dict_of_test_series()
+    polars_series = {}
+    for key in series:
+        try:
+            polars_series[key] = pl.from_pandas(series[key])
+        except (pa.ArrowInvalid, ValueError):
+            pass
+
+    # Add a Polar table with unsigned integers
+    # https://github.com/mwouts/itables/issues/192
+    # https://github.com/mwouts/itables/issues/299
+    polars_series["u32"] = pl.Series([1, 2, 5]).cast(pl.UInt32)
+    polars_series["u64"] = pl.Series([1, 2, 2**40]).cast(pl.UInt64)
+
+    return polars_series
 
 
 @lru_cache()

--- a/tests/test_documentation_notebooks_run.py
+++ b/tests/test_documentation_notebooks_run.py
@@ -12,6 +12,10 @@ try:
     import polars as pl
 except ImportError:
     pl = None
+try:
+    import modin.pandas as mpd
+except ImportError:
+    mpd = None
 
 pytestmark = pytest.mark.skipif(sys.version_info < (3, 8), reason="Require Python>=3.8")
 
@@ -29,6 +33,8 @@ def list_doc_notebooks():
 def test_run_documentation_notebooks(notebook):
     if "polars" in notebook.stem and pl is None:
         pytest.skip("Polars is not available")
+    if "modin" in notebook.stem and mpd is None:
+        pytest.skip("Modin is not available")
     if "pandas_style" in notebook.stem and pd_style is None:
         pytest.skip("Pandas Style is not available")
     if "shiny" in notebook.stem:

--- a/tests/test_modin.py
+++ b/tests/test_modin.py
@@ -1,0 +1,29 @@
+import pytest
+
+from itables import to_html_datatable
+from itables.sample_dfs import get_dict_of_test_modin_dfs, get_dict_of_test_modin_series
+
+try:
+    import modin  # noqa: F401
+except ImportError as e:
+    pytest.skip(str(e), allow_module_level=True)
+
+
+@pytest.fixture(params=get_dict_of_test_modin_dfs().items(), ids=lambda param: param[0])
+def df(request):
+    return request.param[1]
+
+
+@pytest.fixture(
+    params=get_dict_of_test_modin_series().items(), ids=lambda param: param[0]
+)
+def x(request):
+    return request.param[1]
+
+
+def test_show_modin_series(x, use_to_html):
+    to_html_datatable(x, use_to_html)
+
+
+def test_show_modin_df(df, use_to_html):
+    to_html_datatable(df, use_to_html)

--- a/tests/test_polars.py
+++ b/tests/test_polars.py
@@ -2,31 +2,42 @@ import pytest
 
 from itables import to_html_datatable
 from itables.javascript import datatables_rows
-from itables.sample_dfs import get_dict_of_test_dfs, get_dict_of_test_series
+from itables.sample_dfs import (
+    get_dict_of_test_polars_dfs,
+    get_dict_of_test_polars_series,
+)
 
 try:
-    import polars  # noqa
+    import polars as pl  # noqa
 except ImportError as e:
     pytest.skip(str(e), allow_module_level=True)
 
 
-@pytest.mark.parametrize(
-    "name,x", [(name, x) for name, x in get_dict_of_test_series(polars=True).items()]
+@pytest.fixture(
+    params=get_dict_of_test_polars_dfs().items(), ids=lambda param: param[0]
 )
-def test_show_polars_series(name, x, use_to_html):
+def df(request):
+    return request.param[1]
+
+
+@pytest.fixture(
+    params=get_dict_of_test_polars_series().items(), ids=lambda param: param[0]
+)
+def x(request):
+    return request.param[1]
+
+
+def test_show_polars_series(x, use_to_html):
     to_html_datatable(x, use_to_html)
 
 
-@pytest.mark.parametrize(
-    "name,df", [(name, df) for name, df in get_dict_of_test_dfs(polars=True).items()]
-)
-def test_show_polars_df(name, df, use_to_html):
+def test_show_polars_df(df, use_to_html):
     to_html_datatable(df, use_to_html)
 
 
 def test_encode_mixed_contents():
     # Make sure that the bigint escape works for mixed content # 291
-    df = polars.DataFrame(
+    df = pl.DataFrame(
         {
             "bigint": [1666767918216000000],
             "int": [1699300000000],


### PR DESCRIPTION
This PR add tests for Modin dataframes. It is on top of @DeaMariaLeon's PR to add support for more DataFrame types using Narwhals at #339 .

From this quick experiment I would say that the `nbytes` function (estimate the size of the dataframe in bytes) and the `downsample` functions (keep left and right most columns, top and bottom rows) could benefit a bit more from Narwhals.