### PR TITLE
Add `itables_for_dash` to the wheel and sdist

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -122,3 +122,7 @@ jobs:
         run : pip install hatch
       - name: Build package
         run: hatch build
+      - name: Check LICENSE.txt in wheel
+        run: unzip -l dist/*.whl | grep -q itables_for_dash/async-ITable.js.LICENSE.txt
+      - name: Check LICENSE.txt in sdist
+        run: tar -tvf dist/*.tar.gz | grep -q itables_for_dash/async-ITable.js.LICENSE.txt

--- a/environment.yml
+++ b/environment.yml
@@ -26,5 +26,7 @@ dependencies:
   - shinywidgets
   - streamlit
   - anywidget
+  - hatch
+  - dash
   - pip:
     - world_bank_data

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -101,19 +101,21 @@ build_cmd = "build"
 npm = ["npm"]
 
 [tool.hatch.build.targets.sdist]
+packages = ["src/itables", "src/itables_for_dash"]
 artifacts = [
     "src/itables/html/dt_bundle.js",
     "src/itables/html/dt_bundle.css",
-    "src/itables/dash/*",
+    "src/itables_for_dash/*",
     "src/itables/itables_for_streamlit/*",
     "src/itables/widget/static/*"
     ]
 
 [tool.hatch.build.targets.wheel]
+packages = ["src/itables", "src/itables_for_dash"]
 artifacts = [
     "src/itables/html/dt_bundle.js",
     "src/itables/html/dt_bundle.css",
-    "src/itables/dash/*",
+    "src/itables_for_dash/*",
     "src/itables/itables_for_streamlit/*",
     "src/itables/widget/static/*"
     ]


### PR DESCRIPTION
This PR is a follow-up on #358 - it fixes the inclusion of the `itables_for_dash` package in the sdist and wheel.