### PR TITLE
Add more application examples: Shiny and Marimo

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -35,7 +35,6 @@ jobs:
           python -m venv .venv
           source .venv/bin/activate
           pip install pandas-stubs
-          pip install streamlit
           pip install -e .[test]
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
       - name: Run Pyright
@@ -73,7 +72,7 @@ jobs:
             pandas-version: pre
             polars: true
           - python-version: "3.13"
-            uninstall_jinja2_and_dash: true
+            uninstall_non_essential_dependencies: true
           - python-version: "3.10"
             typeguard-version: "<4.4.1"
           - python-version: "3.10"
@@ -115,11 +114,11 @@ jobs:
         run: pip install -e .[polars]
 
       - name: Install shiny
-        run: pip install "shiny>=1.0"
+        run: pip install "shiny>=1.0" shinywidgets
 
-      - name: Uninstall jinja2 and dash
-        if: matrix.uninstall_jinja2_and_dash
-        run: pip uninstall jinja2 dash -y
+      - name: Uninstall non-essential dependencies
+        if: matrix.uninstall_non_essential_dependencies
+        run: pip uninstall jinja2 dash anywidget streamlit shiny shinywidgets -y
 
       - name: Install a Jupyter Kernel
         run: python -m ipykernel install --name itables --user

--- a/apps/marimo/html.py
+++ b/apps/marimo/html.py
@@ -1,0 +1,38 @@
+import marimo
+
+__generated_with = "0.13.6"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    # Using the ITable HTML representation in Marimo
+
+    The `show` method of ITables does not work in Marimo. We recommend
+    that you use the `ITable` widget instead.
+
+    However you can also use the `to_html_datatable` method in combination
+    with `mo.iframe` to display a table in Marimo. You need to pass
+    `connected=True` as the HTML snippet is not able to access the `init_notebook_mode` cell.
+    """
+    )
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    from itables import to_html_datatable
+    from itables.sample_dfs import get_dict_of_test_dfs
+
+    df = get_dict_of_test_dfs()["int_float_str"]
+
+    html = to_html_datatable(df, selected_rows=[0, 2, 5], select=True, connected=True)
+    mo.iframe(html)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/marimo/widget.py
+++ b/apps/marimo/widget.py
@@ -1,0 +1,147 @@
+import marimo
+
+__generated_with = "0.13.6"
+app = marimo.App()
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    # Using the ITable Widget in Marimo
+
+    The `ITable` widget depends on [AnyWidget](https://anywidget.dev) -
+    a great widget development framework! You can install it with
+    ```bash
+    pip install itables[widget]
+    ```
+
+    The `ITable` class accepts the same [options](../options/options.md) as the `show` method, but
+    the `df` argument is optional.
+    """
+    )
+    return
+
+
+@app.cell
+def _():
+    from itables.sample_dfs import get_dict_of_test_dfs
+    from itables.widget import ITable
+
+    df = get_dict_of_test_dfs()["int_float_str"]
+
+    table = ITable(df, selected_rows=[0, 2, 5], select=True)
+    table  # type: ignore[reportUnusedExpression]
+    return df, table
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    💡 The table shown above does not reflect the initial row selection.
+    This is because the `ITable` widget was updated with
+    more row selection commands, see below.
+
+    ## The `selected_rows` traits
+
+    ⚠️ At the moment, the selected rows are not displayed properly in Marimo.
+    Please subscribe to https://github.com/mwouts/itables/issues/383 or reach out if you know how to fix this.
+
+    The `selected_rows` attribute of the `ITable` object provides a view on the
+    rows that have been selected in the table (remember to pass [`select=True`](../options/select.md) to activate the row selection). You can use it to either retrieve
+    or change the current row selection:
+    """
+    )
+    return
+
+
+@app.cell
+def _(table):
+    table.selected_rows
+    return
+
+
+@app.cell
+def _(table):
+    table.selected_rows = [3, 4]
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    ## The `df` property
+
+    Use it to retrieve the table data:
+    """
+    )
+    return
+
+
+@app.cell
+def _(table):
+    table.df.iloc[table.selected_rows]
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(r"""or to update it""")
+    return
+
+
+@app.cell
+def _(df, table):
+    table.df = df.head(6)
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    💡 `ITable` raises an `IndexError` if the `selected_rows` are not consistent with the data. If you need to update both simultaneously, use `table.update(df, selected_rows=...)`, see below.
+
+    ## The `caption`, `style` and `classes` traits
+
+    You can update these traits from Python, e.g.
+    """
+    )
+    return
+
+
+@app.cell
+def _(table):
+    table.caption = "numbers and strings"
+    return
+
+
+@app.cell(hide_code=True)
+def _(mo):
+    mo.md(
+        r"""
+    ## The `update` method
+
+    Last but not least, you can update the `ITable` arguments simultaneously using the `update` method:
+    """
+    )
+    return
+
+
+@app.cell
+def _(df, table):
+    table.update(df.head(20), selected_rows=[7, 8])
+    return
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    return (mo,)
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/shiny/README.md
+++ b/apps/shiny/README.md
@@ -1,0 +1,38 @@
+# ITables in Shiny for Python: a Demo
+
+This directory contains two example Python for Shiny applications that render
+Pandas DataFrames using [ITables](https://mwouts.github.io/itables).
+
+## The ITable Widget
+
+This is the recommended way to use ITable in a Shiny application.
+
+See the source code at [`app.py`](itable_widget/app.py) (Shiny Express) or [`app-core.py`](itable_widget/app-core.py) (Shiny Core).
+
+Install the requirements with
+```
+pip install -r itable_widget/requirements.txt
+```
+and launch the app with
+```
+shiny run itable_widget/app-express.py  # or app-core.py
+```
+
+Or access the app online at https://itables.shinyapps.io/itable_widget/
+
+## Using DT
+
+This is an alternative way to use ITable in a Shiny application.
+
+See the source code at [`app.py`](itables_DT/app.py) (Shiny Express) or [`app-core.py`](itables_DT/app-core.py) (Shiny Core).
+
+Install the requirements with
+```
+pip install -r itables_DT/requirements.txt
+```
+and launch the app with
+```
+shiny run itables_DT/app-express.py  # or app-core.py
+```
+
+Or access the app online at https://itables.shinyapps.io/itables_DT/

--- a/apps/shiny/itable_widget/app-core.py
+++ b/apps/shiny/itable_widget/app-core.py
@@ -1,0 +1,65 @@
+from shiny import App, reactive, render, ui
+from shinywidgets import output_widget, reactive_read, render_widget
+
+from itables.sample_dfs import get_dict_of_test_dfs
+from itables.widget import ITable
+
+dfs = get_dict_of_test_dfs()
+
+app_ui = ui.page_sidebar(
+    ui.sidebar(
+        ui.input_select(
+            "table_selector",
+            "Table",
+            choices=list(dfs.keys()),
+            selected="int_float_str",
+        )
+    ),
+    output_widget("my_table"),
+    ui.markdown("Selected rows"),
+    ui.output_code("selected_rows"),
+    title="Using the ITable Widget in a Shiny App",
+    fillable=True,
+)
+
+
+def server(input, output, session):
+    @render_widget
+    def my_table():
+        """
+        This function creates the "my_table" widget. While we could
+        pass the df or the other arguments here, it's nicer
+        to use a "reactive.effect" to update the widget
+        """
+        return ITable(caption="A table rendered with ITable", select=True)
+
+    @reactive.effect
+    def _():
+        """
+        This "reactive.effect" uses the "update" method of the ITable widget
+        to update the widget with the new inputs.
+        """
+        # Get the new inputs
+        df = dfs[input.table_selector()]
+        selected_rows = list(range(0, len(df), 3))
+
+        # Update the widget
+        assert isinstance(
+            my_table.widget, ITable
+        )  # otherwise pyright complains it might be None
+        my_table.widget.update(df, selected_rows=selected_rows)
+
+    ui.markdown("Selected rows")
+
+    @render.code
+    def selected_rows():
+        """
+        Here we read the "selected_rows" attribute of the ITable widget
+        """
+        assert isinstance(
+            my_table.widget, ITable
+        )  # otherwise pyright complains it might be None
+        return str(reactive_read(my_table.widget, "selected_rows"))
+
+
+app = App(app_ui, server)

--- a/apps/shiny/itable_widget/app.py
+++ b/apps/shiny/itable_widget/app.py
@@ -1,0 +1,57 @@
+from shiny import reactive
+from shiny.express import input, render, ui
+from shinywidgets import reactive_read, render_widget
+
+from itables.sample_dfs import get_dict_of_test_dfs
+from itables.widget import ITable
+
+dfs = get_dict_of_test_dfs()
+
+ui.page_opts(title="Using the ITable Widget in a Shiny App", fillable=True)
+
+with ui.card():
+    with ui.layout_sidebar():
+        with ui.sidebar():
+            ui.input_select(
+                "table_selector",
+                "Table",
+                choices=list(dfs.keys()),
+                selected="int_float_str",
+            )
+
+        @render_widget
+        def my_table():
+            """
+            This function creates the "my_table" widget. While we could
+            pass the df or the other arguments here, it's nicer
+            to use a "reactive.effect" to update the widget
+            """
+            return ITable(caption="A table rendered with ITable", select=True)
+
+        @reactive.effect
+        def _():
+            """
+            This "reactive.effect" uses the "update" method of the ITable widget
+            to update the widget with the new inputs.
+            """
+            # Get the new inputs
+            df = dfs[input.table_selector()]
+            selected_rows = list(range(0, len(df), 3))
+
+            # Update the widget
+            assert isinstance(
+                my_table.widget, ITable
+            )  # otherwise pyright complains it might be None
+            my_table.widget.update(df, selected_rows=selected_rows)
+
+        ui.markdown("Selected rows")
+
+        @render.code
+        def selected_rows():
+            """
+            Here we read the "selected_rows" attribute of the ITable widget
+            """
+            assert isinstance(
+                my_table.widget, ITable
+            )  # otherwise pyright complains it might be None
+            return str(reactive_read(my_table.widget, "selected_rows"))

--- a/apps/shiny/itable_widget/requirements.txt
+++ b/apps/shiny/itable_widget/requirements.txt
@@ -1,0 +1,4 @@
+itables>=2.2
+shiny
+shinywidgets
+anywidget

--- a/apps/shiny/itable_widget/rsconnect-python/itable_widget.json
+++ b/apps/shiny/itable_widget/rsconnect-python/itable_widget.json
@@ -1,0 +1,12 @@
+{
+    "https://api.shinyapps.io": {
+        "server_url": "https://api.shinyapps.io",
+        "filename": "/home/marc/GitHub/itables/apps/shiny/itable_widget",
+        "app_url": "https://itables.shinyapps.io/itable_widget/",
+        "app_id": 12865888,
+        "app_guid": null,
+        "title": "itable_widget",
+        "app_mode": "python-shiny",
+        "app_store_version": 1
+    }
+}

--- a/apps/shiny/itables_DT/app-core.py
+++ b/apps/shiny/itables_DT/app-core.py
@@ -1,0 +1,37 @@
+from shiny import App, render, ui
+
+from itables.sample_dfs import get_dict_of_test_dfs
+from itables.shiny import DT, init_itables
+
+dfs = get_dict_of_test_dfs()
+
+app_ui = ui.page_sidebar(
+    ui.sidebar(
+        ui.input_select(
+            "table_selector",
+            "Table",
+            choices=list(dfs.keys()),
+            selected="int_float_str",
+        )
+    ),
+    ui.HTML(init_itables()),
+    ui.output_ui("my_table"),
+    ui.markdown("Selected rows"),
+    ui.output_code("selected_rows"),
+    title="Using DT in a Shiny App",
+    fillable=True,
+)
+
+
+def server(input, output, session):
+    @render.ui
+    def my_table():
+        """
+        This function renders the table using "DT".
+        """
+        df = dfs[input.table_selector()]
+
+        return ui.HTML(DT(df))
+
+
+app = App(app_ui, server)

--- a/apps/shiny/itables_DT/app.py
+++ b/apps/shiny/itables_DT/app.py
@@ -1,0 +1,28 @@
+from shiny.express import input, render, ui
+
+from itables.sample_dfs import get_dict_of_test_dfs
+from itables.shiny import DT, init_itables
+
+dfs = get_dict_of_test_dfs()
+
+ui.page_opts(title="Using DT in a Shiny App", fillable=True)
+
+with ui.card():
+    with ui.layout_sidebar():
+        with ui.sidebar():
+            ui.input_select(
+                "table_selector",
+                "Table",
+                choices=list(dfs.keys()),
+                selected="int_float_str",
+            )
+
+        ui.HTML(init_itables())
+
+        @render.ui
+        def my_table():
+            """
+            This function renders the table using "DT".
+            """
+            df = dfs[input.table_selector()]
+            return ui.HTML(DT(df, caption="A table rendered with ITable"))

--- a/apps/shiny/itables_DT/requirements.txt
+++ b/apps/shiny/itables_DT/requirements.txt
@@ -1,0 +1,2 @@
+itables>=2.2
+shiny

--- a/apps/shiny/itables_DT/rsconnect-python/itables_DT.json
+++ b/apps/shiny/itables_DT/rsconnect-python/itables_DT.json
@@ -1,0 +1,12 @@
+{
+    "https://api.shinyapps.io": {
+        "server_url": "https://api.shinyapps.io",
+        "filename": "/home/marc/GitHub/itables/apps/shiny/itables_DT",
+        "app_url": "https://itables.shinyapps.io/itables_dt/",
+        "app_id": 12865873,
+        "app_guid": null,
+        "title": "itables_DT",
+        "app_mode": "python-shiny",
+        "app_store_version": 1
+    }
+}

--- a/apps/streamlit/itables_app.py
+++ b/apps/streamlit/itables_app.py
@@ -4,7 +4,17 @@ from typing import Sequence, cast
 
 import pyarrow
 import streamlit as st
-from st_aggrid import AgGrid  # type: ignore
+
+try:
+    from st_aggrid import AgGrid  # type: ignore
+except ImportError as e:
+    import_error = e
+
+    class AgGrid:
+        def __init__(self, *args, **kwargs):
+            raise import_error
+
+
 from streamlit.components.v1.components import MarshallComponentException
 
 import itables.options as it_opt

--- a/docs/_toc.yml
+++ b/docs/_toc.yml
@@ -6,6 +6,7 @@ parts:
       - file: apps/notebook
       - file: apps/html
       - file: apps/widget
+      - file: apps/marimo
       - file: apps/dash
       - file: apps/streamlit
       - file: apps/shiny

--- a/docs/apps/marimo.md
+++ b/docs/apps/marimo.md
@@ -1,0 +1,49 @@
+---
+jupytext:
+  formats: md:myst
+  notebook_metadata_filter: -jupytext.text_representation.jupytext_version
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: itables
+  language: python
+  name: itables
+---
+
+# Marimo
+
+```{warning}
+The `init_notebook_mode` and the `show` function do not work in Marimo. This is because they both use `IPython.display` to display the HTML representation of the table, which is not a good fit for Marimo.
+```
+
+In Marimo the recommended way to use ITable is through the `ITable` [widget](widget.md):
+
+```{code-cell} ipython3
+import pandas as pd
+
+from itables.widget import ITable
+
+df = pd.DataFrame({"x": [2, 1, 3]})
+
+ITable(df)
+```
+
+A Sample Marimo application is available at [`apps/marimo/widget.py`](https://github.com/mwouts/itables/tree/main/apps/marimo/widget.py).
+
+
+## Using HTML
+
+You can also use `to_html_datatable` in combination with `mo.iframe` like in this example - but, as there is no `init_notebook_mode` cell, you will have to use the connected mode:
+
+```python
+import marimo as mo
+
+from itables import to_html_datatable
+
+html = to_html_datatable(df, connected=True)
+mo.iframe(html)
+```
+
+A Sample Marimo application that uses `to_html_datatable` is available at [`apps/marimo/html.py`](https://github.com/mwouts/itables/tree/main/apps/marimo/html.py).

--- a/docs/apps/shiny.md
+++ b/docs/apps/shiny.md
@@ -83,12 +83,12 @@ def selected_rows():
 
 ## An example application
 
-This [repository](https://github.com/mwouts/demo_itables_in_shiny-py/) contains a simple
+The ITable [repository](https://github.com/mwouts/itables/tree/main/apps/shiny) contains a simple
 example of a Shiny application that uses the `ITable` widget.
 
 The source code of the application
-is at [`app.py`](https://github.com/mwouts/demo_itables_in_shiny-py/blob/main/itable_widget/app.py)
-(Shiny Express) or [`app-core.py`](https://github.com/mwouts/demo_itables_in_shiny-py/blob/main/itable_widget/app-core.py)
+is at [`app.py`](https://github.com/mwouts/itables/tree/main/apps/shiny/itable_widget/app.py)
+(Shiny Express) or [`app-core.py`](https://github.com/mwouts/itables/tree/main/apps/shiny/itable_widget/app-core.py)
 (Shiny Core).
 
 ```{div}
@@ -98,7 +98,7 @@ style="height: 800px; width: 100%;"></iframe>
 
 ## DT
 
-Before ITables v2.4.0, the Jupyter Widget had some limitations compared to the direct HTML implementation. The widget should now be up to par with the HTML version, however you can still use `HTML(DT(...))` if you only want to _display_ the table:
+Before ITables v2.4.0, the Jupyter Widget had some limitations compared to the direct HTML implementation. The widget is now on par with the HTML version, however you can still use `HTML(DT(...))` if you only want to _display_ the table:
 
 ```python
 from shiny import ui
@@ -114,8 +114,8 @@ ui.HTML(init_itables())
 ui.HTML(DT(get_countries(html=False)))
 ```
 
-An example for an application that uses `DT` is available at [`app.py`](https://github.com/mwouts/demo_itables_in_shiny-py/blob/main/itables_DT/app.py)
-(Shiny Express) or [`app-core.py`](https://github.com/mwouts/demo_itables_in_shiny-py/blob/main/itables_DT/app-core.py)
+An example for an application that uses `DT` is available at [`app.py`](https://github.com/mwouts/itables/tree/main/apps/shiny/itables_DT/app.py)
+(Shiny Express) or [`app-core.py`](https://github.com/mwouts/itables/tree/main/apps/shiny/itables_DT/app-core.py)
 (Shiny Core).
 
 ```{div}

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,7 @@ ITables ChangeLog
 **Added**
 - The ITable widget, and the ITable components for Dash and Streamlit have the same features as the `show` function. They can show non-finite floats, bigints, Pandas Style objects and use custom JavaScript formatters ([#374](https://github.com/mwouts/itables/issues/374))
 - We have added type hints for the `show` function and for the various app components. A SyntaxWarning is issued if either the argument name or type does not match when `warn_on_undocumented_option=True` (the default when `typeguard>=4.4.1` is installed)
+- We have added more application examples, and documented how to use ITables in Marimo ([#348](https://github.com/mwouts/itables/issues/348))
 
 **Changed**
 - By default, the HTML content in Pandas and Polars dataframes is now escaped. Use `allow_html=True` to display HTML content (use this option only if you trust the content of the table!) ([#346](https://github.com/mwouts/itables/issues/346))

--- a/environment.yml
+++ b/environment.yml
@@ -24,12 +24,13 @@ dependencies:
   - setuptools
   - twine
   - ghp-import
+  - anywidget
+  - dash
+  - marimo
   - shiny
   - shinywidgets
   - streamlit
-  - anywidget
   - hatch
-  - dash
   - pip:
     - world_bank_data
     - sphinxext-rediraffe

--- a/packages/dt_for_itables/CHANGELOG.md
+++ b/packages/dt_for_itables/CHANGELOG.md
@@ -1,3 +1,7 @@
+# 2.3.2 (2025-05-17)
+
+- We have fixed an issue with `selected_rows` when `filtered_row_count` was not explicitly set.
+
 # 2.3.1 (2025-05-17)
 
 - We have improved the implementation of `text_in_header_can_be_selected`.

--- a/packages/dt_for_itables/package-lock.json
+++ b/packages/dt_for_itables/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "dt_for_itables",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "dt_for_itables",
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "datatables.net-buttons": "^3.0.1",

--- a/packages/dt_for_itables/package.json
+++ b/packages/dt_for_itables/package.json
@@ -1,6 +1,6 @@
 {
   "name": "dt_for_itables",
-  "version": "2.3.1",
+  "version": "2.3.2",
   "description": "DataTables bundle for itables",
   "main": "src/index.js",
   "typings": "src/index.d.js",

--- a/packages/dt_for_itables/src/index.js
+++ b/packages/dt_for_itables/src/index.js
@@ -83,7 +83,7 @@ class ITable {
             keys_to_be_evaluated.forEach(keys => evalNestedKeys(dt_args, keys, keys.join('.')));
         }
 
-        this.filtered_row_count = filtered_row_count;
+        this.filtered_row_count = filtered_row_count || 0;
 
         if (text_in_header_can_be_selected || column_filters) {
             dt_args.initComplete = function (settings, json) {

--- a/packages/itables_anywidget/package-lock.json
+++ b/packages/itables_anywidget/package-lock.json
@@ -14,7 +14,7 @@
 			}
 		},
 		"../dt_for_itables": {
-			"version": "2.3.1",
+			"version": "2.3.2",
 			"license": "MIT",
 			"dependencies": {
 				"datatables.net-buttons": "^3.0.1",

--- a/packages/itables_for_dash/package-lock.json
+++ b/packages/itables_for_dash/package-lock.json
@@ -33,7 +33,7 @@
       }
     },
     "../dt_for_itables": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "datatables.net-buttons": "^3.0.1",

--- a/packages/itables_for_streamlit/package-lock.json
+++ b/packages/itables_for_streamlit/package-lock.json
@@ -20,7 +20,7 @@
       }
     },
     "../dt_for_itables": {
-      "version": "2.3.1",
+      "version": "2.3.2",
       "license": "MIT",
       "dependencies": {
         "datatables.net-buttons": "^3.0.1",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -34,7 +34,10 @@ check_type = ["typeguard>=4.4.1"]
 style = ["matplotlib"]
 samples = ["pytz", "world_bank_data"]
 widget = ["anywidget", "traitlets"]
-all = ["itables[polars,style,samples,widget,check_type]"]
+streamlit = ["streamlit"]
+dash = ["dash"]
+shiny = ["shiny", "shinywidgets"]
+all = ["itables[polars,style,samples,widget,dash,shiny,streamlit,check_type]"]
 test = [
   "itables[all]",
   # Pytest
@@ -44,10 +47,8 @@ test = [
   "ipykernel",
   "nbconvert",
   "jupytext",
-  # Python apps
-  "dash",
-  "shiny",
-  # "shinywidgets",
+  # Marimo app
+  "marimo",
   # Test urls
   "requests",
 ]

--- a/src/itables/__init__.py
+++ b/src/itables/__init__.py
@@ -1,4 +1,4 @@
-from itables import downsample, options, sample_dfs, widget
+from itables import downsample, options, sample_dfs
 
 from .javascript import init_notebook_mode, show, to_html_datatable
 from .typing import JavascriptCode, JavascriptFunction
@@ -14,5 +14,4 @@ __all__ = [
     "options",
     "downsample",
     "sample_dfs",
-    "widget",
 ]

--- a/src/itables/streamlit.py
+++ b/src/itables/streamlit.py
@@ -1,3 +1,5 @@
+from typing import Optional
+
 import streamlit.components.v1 as components
 from typing_extensions import Unpack
 
@@ -10,7 +12,9 @@ _streamlit_component_func = components.declare_component(
 )
 
 
-def interactive_table(df, key: str, *args, **kwargs: Unpack[ITableOptions]):
+def interactive_table(
+    df, key: Optional[str] = None, *args, **kwargs: Unpack[ITableOptions]
+):
     """Render the DataFrame as an interactive datatable in Streamlit applications"""
     dt_args, other_args = get_itables_extension_arguments(df, *args, **kwargs)
     return _streamlit_component_func(key=key, dt_args=dt_args, other_args=other_args)

--- a/src/itables/utils.py
+++ b/src/itables/utils.py
@@ -1,7 +1,7 @@
 from io import open
 from pathlib import Path
 
-UNPKG_DT_BUNDLE_URL = "https://www.unpkg.com/dt_for_itables@2.3.1/dt_bundle.js"
+UNPKG_DT_BUNDLE_URL = "https://www.unpkg.com/dt_for_itables@2.3.2/dt_bundle.js"
 UNPKG_DT_BUNDLE_CSS = UNPKG_DT_BUNDLE_URL.replace(".js", ".css")
 UNPKG_DT_BUNDLE_URL_NO_VERSION = "https://www.unpkg.com/dt_for_itables/dt_bundle.js"
 UNPKG_DT_BUNDLE_CSS_NO_VERSION = "https://www.unpkg.com/dt_for_itables/dt_bundle.css"

--- a/src/itables/widget/__init__.py
+++ b/src/itables/widget/__init__.py
@@ -22,7 +22,7 @@ class ITable(anywidget.AnyWidget):
     caption = traitlets.Unicode().tag(sync=True)
     classes = traitlets.Unicode().tag(sync=True)
     style = traitlets.Unicode().tag(sync=True)
-    selected_rows = traitlets.List(traitlets.Int).tag(sync=True)  # type: ignore
+    selected_rows = traitlets.List(traitlets.Int()).tag(sync=True)
 
     # private traits that relate to df or to the DataTable arguments
     # (use .update() to update them)

--- a/tests/test_documentation_notebooks_run.py
+++ b/tests/test_documentation_notebooks_run.py
@@ -36,6 +36,8 @@ def test_run_documentation_notebooks(notebook):
         pytest.skip("Pandas Style is not available")
     if "shiny" in notebook.stem:
         pytest.skip("shinywidgets makes the widget.md notebook fail")
+    if "marimo" in notebook.stem or "widget" in notebook.stem:
+        pytest.importorskip("anywidget")
 
     org_options = dir(opt)
 

--- a/tests/test_marimo.py
+++ b/tests/test_marimo.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+MARIMO_APPS_PATH = Path(__file__).parent / ".." / "apps" / "marimo"
+MARIMO_APPS_PY_FILES = [
+    file for file in MARIMO_APPS_PATH.iterdir() if file.suffix == ".py"
+]
+
+pytest.importorskip("marimo")
+
+
+@pytest.fixture(params=MARIMO_APPS_PY_FILES)
+def marimo_app(request) -> str:
+    """Return the name of an example Marimo app"""
+    return request.param.stem
+
+
+def test_marimo_apps_exist():
+    assert (
+        len(MARIMO_APPS_PY_FILES) > 0
+    ), "No Marimo apps found in the apps/marimo directory."
+
+
+def test_marimo_apps_are_valid_python_scripts(marimo_app: str):
+    """Test that the Marimo apps are valid Python scripts."""
+    file_path = MARIMO_APPS_PATH / f"{marimo_app}.py"
+    spec = importlib.util.spec_from_file_location(marimo_app, file_path)
+    assert spec is not None, f"Could not find spec for {marimo_app}"
+    app = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app)  # type: ignore
+    assert app is not None

--- a/tests/test_streamlit.py
+++ b/tests/test_streamlit.py
@@ -1,0 +1,33 @@
+import importlib.util
+from pathlib import Path
+
+import pytest
+
+STREAMLIT_APPS_PATH = Path(__file__).parent / ".." / "apps" / "streamlit"
+STREAMLIT_APPS_PY_FILES = [
+    file for file in STREAMLIT_APPS_PATH.iterdir() if file.suffix == ".py"
+]
+
+pytest.importorskip("streamlit")
+
+
+@pytest.fixture(params=STREAMLIT_APPS_PY_FILES)
+def streamlit_app(request) -> str:
+    """Return the name of an example Streamlit app"""
+    return request.param.stem
+
+
+def test_streamlit_apps_exist():
+    assert (
+        len(STREAMLIT_APPS_PY_FILES) > 0
+    ), "No Streamlit apps found in the apps/streamlit directory."
+
+
+def test_streamlit_apps_can_be_imported(streamlit_app: str):
+    """Test that the Streamlit apps can be imported successfully."""
+    file_path = STREAMLIT_APPS_PATH / f"{streamlit_app}.py"
+    spec = importlib.util.spec_from_file_location(streamlit_app, file_path)
+    assert spec is not None, f"Could not find spec for {streamlit_app}"
+    app = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(app)  # type: ignore
+    assert app is not None

--- a/tests/test_widget.py
+++ b/tests/test_widget.py
@@ -1,8 +1,13 @@
+import pytest
+
 import itables.options as opt
-from itables.widget import ITable
+
+pytest.importorskip("anywidget")
 
 
 def test_create_widget_with_no_df():
+    from itables.widget import ITable
+
     itable = ITable()
     assert itable._df is None
     assert itable.caption == ""
@@ -17,6 +22,8 @@ def test_create_widget_with_no_df():
 
 
 def test_create_widget_with_df(df):
+    from itables.widget import ITable
+
     itable = ITable(df)
     assert itable.df is df
     assert itable.caption == ""


### PR DESCRIPTION
- Updated `dt_for_itables` to v2.3.2 (fixes an issue with `selected_rows`)
- Added a default value `key=None` in the streamlit component (https://github.com/mwouts/itables/issues/374)
- Added tests on the example applications
- Make sure that ITables works when its optional dependencies are not installed

Closes https://github.com/mwouts/itables/issues/348