### PR TITLE
Move the CSS imports to .css files

### DIFF
--- a/apps/marimo/column_visibility.py
+++ b/apps/marimo/column_visibility.py
@@ -22,7 +22,24 @@ def _():
 
     df = pd.DataFrame({"x": [2, 1, 3], "y": list("cbc")})
 
+    # buttons that trigger a drop-down don't work in Marimo when using the widget
+    # see below for a workaround using mo.iframe
     ITable(df, buttons=["pageLength", "copyHtml5", "csvHtml5", "excelHtml5", "colvis"])
+    return (df,)
+
+
+@app.cell
+def _(df):
+    import marimo as mo
+
+    import itables
+
+    html = itables.to_html_datatable(
+        df,
+        buttons=["pageLength", "copyHtml5", "csvHtml5", "excelHtml5", "colvis"],
+        connected=True,
+    )
+    mo.iframe(html)
     return
 
 

--- a/apps/marimo/column_visibility.py
+++ b/apps/marimo/column_visibility.py
@@ -1,0 +1,35 @@
+# /// script
+# requires-python = ">=3.12,<3.13"
+# dependencies = [
+#     "anywidget==0.9.18",
+#     "itables==2.4.0",
+#     "marimo",
+#     "pandas==2.2.3",
+# ]
+# ///
+
+import marimo
+
+__generated_with = "0.13.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import pandas as pd
+
+    from itables.widget import ITable
+
+    df = pd.DataFrame({"x": [2, 1, 3], "y": list("cbc")})
+
+    ITable(df, buttons=["pageLength", "copyHtml5", "csvHtml5", "excelHtml5", "colvis"])
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/marimo/search_panes.py
+++ b/apps/marimo/search_panes.py
@@ -1,0 +1,34 @@
+import marimo
+
+__generated_with = "0.13.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import marimo as mo
+
+    from itables.sample_dfs import get_countries
+    from itables.widget import ITable
+
+    mo.output.append(
+        ITable(
+            get_countries(html=False, climate_zone=True).reset_index(),
+            layout={"top1": "searchPanes"},
+            searchPanes={
+                "layout": "columns-3",
+                "cascadePanes": True,
+                "columns": [1, 6, 7],
+            },
+        )
+    )
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/marimo/selected_rows.py
+++ b/apps/marimo/selected_rows.py
@@ -1,0 +1,32 @@
+import marimo
+
+__generated_with = "0.13.6"
+app = marimo.App(width="medium")
+
+
+@app.cell
+def _():
+    import pandas as pd
+
+    from itables.widget import ITable
+
+    df = pd.DataFrame({"i": range(6)})
+
+    w = ITable(df, select=True, selected_rows=[1, 4])
+    w
+    return (w,)
+
+
+@app.cell
+def _(w):
+    w._css
+    return
+
+
+@app.cell
+def _():
+    return
+
+
+if __name__ == "__main__":
+    app.run()

--- a/apps/marimo/widget.py
+++ b/apps/marimo/widget.py
@@ -42,15 +42,6 @@ def _(mo):
     💡 The table shown above does not reflect the initial row selection.
     This is because the `ITable` widget was updated with
     more row selection commands, see below.
-
-    ## The `selected_rows` traits
-
-    ⚠️ At the moment, the selected rows are not displayed properly in Marimo.
-    Please subscribe to https://github.com/mwouts/itables/issues/383 or reach out if you know how to fix this.
-
-    The `selected_rows` attribute of the `ITable` object provides a view on the
-    rows that have been selected in the table (remember to pass [`select=True`](../options/select.md) to activate the row selection). You can use it to either retrieve
-    or change the current row selection:
     """
     )
     return

--- a/docs/apps/marimo.md
+++ b/docs/apps/marimo.md
@@ -32,6 +32,7 @@ ITable(df)
 
 A Sample Marimo application is available at [`apps/marimo/widget.py`](https://github.com/mwouts/itables/tree/main/apps/marimo/widget.py).
 
+⚠️ Some datatables buttons don't work when using the ITable widget within Marimo, see [issue #387](https://github.com/mwouts/itables/issues/387). The next paragraph provides a workaround.
 
 ## Using HTML
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -16,6 +16,7 @@ ITables ChangeLog
 - We have added type hints to `itable.options` even for the options that don't have a default value ([#224](https://github.com/mwouts/itables/issues/224))
 - The optional final semicolon in `style` argument is now supported again ([#386](https://github.com/mwouts/itables/issues/386))
 - The index of Pandas Style object is now rendered when non-trivial ([#393](https://github.com/mwouts/itables/issues/393))
+- We have made the CSS files compatible with the shadow dom used by Marimo ([#383](https://github.com/mwouts/itables/issues/383))
 
 
 2.4.0 (2025-05-17)

--- a/docs/py/apps/marimo.py
+++ b/docs/py/apps/marimo.py
@@ -35,6 +35,7 @@ ITable(df)
 # %% [markdown]
 # A Sample Marimo application is available at [`apps/marimo/widget.py`](https://github.com/mwouts/itables/tree/main/apps/marimo/widget.py).
 #
+# ⚠️ Some datatables buttons don't work when using the ITable widget within Marimo, see [issue #387](https://github.com/mwouts/itables/issues/387). The next paragraph provides a workaround.
 #
 # ## Using HTML
 #

--- a/packages/dt_for_itables/CHANGELOG.md
+++ b/packages/dt_for_itables/CHANGELOG.md
@@ -1,7 +1,7 @@
 # 2.3.2+dev
 
 - We have made sure that the ordering icons on empty headers do not reappear when ordering a column
-- Wrapping Javascript functions definitions within parentheses before evaluating is now done on the Javascript side.
+- Wrapping Javascript functions definitions within parentheses before evaluating is now done on the Javascript side
 - The CSS imports have been moved to the `.css` files, and we extend the `:root` styles to `:host`
 
 

--- a/packages/dt_for_itables/CHANGELOG.md
+++ b/packages/dt_for_itables/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 - We have made sure that the ordering icons on empty headers do not reappear when ordering a column
 - Wrapping Javascript functions definitions within parentheses before evaluating is now done on the Javascript side.
+- The CSS imports have been moved to the `.css` files, and we extend the `:root` styles to `:host`
+
 
 # 2.3.2 (2025-05-17)
 

--- a/packages/dt_for_itables/add_host_to_root.py
+++ b/packages/dt_for_itables/add_host_to_root.py
@@ -1,0 +1,91 @@
+#! /usr/bin/env python3
+"""This is a Python script that modifies the dt_bundle.css to
+add :host to each :root selector. This ensures that the styles
+works in Marimo which uses Shadow DOM.
+"""
+
+import argparse
+import re
+import sys
+import warnings
+
+
+def add_host_to_root(css_content: str) -> str:
+    """
+    Add :host to each :root selector in the given CSS content.
+    """
+    if ":host" in css_content:
+        raise ValueError("The CSS content already contains ':host'")
+
+    # If the content is empty, return it as is
+    if not css_content.strip():
+        return css_content
+
+    # Process each rule separately
+    def process_rule(match):
+        spaces_before = match.group(1)
+        selector_group = match.group(2)
+        properties = match.group(3)
+
+        # Extract trailing whitespace from selector_group
+        stripped_selector_group = selector_group.rstrip()
+        spaces_after = selector_group[len(stripped_selector_group) :]
+        selector_group = stripped_selector_group
+
+        # If no :root in the selector, return the rule as is
+        if ":root" not in selector_group:
+            return f"{spaces_before}{selector_group}{spaces_after}{properties}"
+
+        new_selectors = []
+
+        # Split by commas to get individual selectors
+        for selector in selector_group.split(","):
+            striped_selector = selector.lstrip()
+            new_selectors.append(striped_selector)
+            if not striped_selector.startswith(":root"):
+                continue
+            if striped_selector == ":root" or striped_selector.startswith(
+                (":root ", ":root.", ":root[")
+            ):
+                new_selectors.append(striped_selector.replace(":root", ":host", 1))
+            else:
+                warnings.warn(
+                    f"Selector '{striped_selector}' contains ':root' but is not a simple ':root' selector. "
+                    "It will not be modified."
+                )
+
+        return f"{spaces_before}{(', ').join(new_selectors)}{spaces_after}{properties}"
+
+    # Match CSS rules: selector(s) { properties }
+    pattern = r"(\s*)([^{]+)({[^}]*})"
+    return re.sub(pattern, process_rule, css_content)
+
+
+if __name__ == "__main__":
+
+    def main():
+        parser = argparse.ArgumentParser(
+            description="Add :host to each :root selector in a CSS file."
+        )
+        parser.add_argument("css_file", help="Path to the CSS file to modify")
+        args = parser.parse_args()
+
+        try:
+            with open(args.css_file, "r") as file:
+                css_content = file.read()
+
+            modified_content = add_host_to_root(css_content)
+
+            with open(args.css_file, "w") as file:
+                file.write(modified_content)
+
+            print(f"Successfully updated {args.css_file}")
+            return 0
+        except FileNotFoundError:
+            print(f"Error: File {args.css_file} not found.")
+            return 1
+        except Exception as e:
+            print(f"Error processing file: {e}")
+            return 1
+
+    sys.exit(main())

--- a/packages/dt_for_itables/package.json
+++ b/packages/dt_for_itables/package.json
@@ -17,8 +17,11 @@
   ],
   "scripts": {
     "build:js": "esbuild src/index.js --format=esm --bundle --outfile=dt_bundle.js --minify",
-    "install:js": "cp dt_bundle.js dt_bundle.css  ../../src/itables/html",
-    "build": "npm run build:js && npm run install:js"
+    "build:css": "esbuild src/index.css  --bundle --outfile=dt_bundle.css --minify",
+    "add_host": "python add_host_to_root.py dt_bundle.css",
+    "build:all": "npm run build:js && npm run build:css && npm run add_host",
+    "install:all": "cp dt_bundle.js dt_bundle.css  ../../src/itables/html",
+    "build": "npm run build:all && npm run install:all"
   },
   "author": "Marc Wouts",
   "license": "MIT",

--- a/packages/dt_for_itables/src/index.css
+++ b/packages/dt_for_itables/src/index.css
@@ -1,3 +1,14 @@
+@import 'datatables.net-dt/css/dataTables.dataTables.min.css';
+@import 'datatables.net-buttons-dt/css/buttons.dataTables.min.css';
+@import 'datatables.net-fixedcolumns-dt/css/fixedColumns.dataTables.min.css';
+@import 'datatables.net-keytable-dt/css/keyTable.dataTables.min.css';
+@import 'datatables.net-rowgroup-dt/css/rowGroup.dataTables.min.css';
+@import 'datatables.net-datetime/dist/dataTables.dateTime.min.css';
+@import 'datatables.net-searchbuilder-dt/css/searchBuilder.dataTables.min.css';
+@import 'datatables.net-searchpanes-dt/css/searchPanes.dataTables.min.css';
+@import 'datatables.net-select-dt/css/select.dataTables.min.css';
+
+
 div.dt-container {
     max-width: 100%;
 }

--- a/packages/dt_for_itables/src/index.js
+++ b/packages/dt_for_itables/src/index.js
@@ -2,38 +2,21 @@ import JSZip from 'jszip';
 import jQuery from 'jquery';
 
 import DataTable from 'datatables.net-dt';
-import 'datatables.net-dt/css/dataTables.dataTables.min.css';
 
 import 'datatables.net-buttons-dt';
 import 'datatables.net-buttons/js/buttons.html5.min.mjs';
 import 'datatables.net-buttons/js/buttons.print.min.mjs';
 import 'datatables.net-buttons/js/buttons.colVis.min.mjs';
-import 'datatables.net-buttons-dt/css/buttons.dataTables.min.css';
 
 DataTable.Buttons.jszip(JSZip);
 
 import 'datatables.net-fixedcolumns-dt';
-import 'datatables.net-fixedcolumns-dt/css/fixedColumns.dataTables.min.css';
-
 import 'datatables.net-keytable-dt';
-import 'datatables.net-keytable-dt/css/keyTable.dataTables.min.css';
-
 import 'datatables.net-rowgroup-dt';
-import 'datatables.net-rowgroup-dt/css/rowGroup.dataTables.min.css';
-
 import DateTime from 'datatables.net-datetime';
-import 'datatables.net-datetime/dist/dataTables.dateTime.min.css';
-
 import 'datatables.net-searchbuilder-dt';
-import 'datatables.net-searchbuilder-dt/css/searchBuilder.dataTables.min.css';
-
 import 'datatables.net-searchpanes-dt';
-import 'datatables.net-searchpanes-dt/css/searchPanes.dataTables.min.css';
-
 import 'datatables.net-select-dt';
-import 'datatables.net-select-dt/css/select.dataTables.min.css';
-
-import './index.css';
 
 function parseJSON(jsonString) {
     return JSON.parse(jsonString, (key, value, context) => {

--- a/packages/dt_for_itables/test_add_host_to_root.py
+++ b/packages/dt_for_itables/test_add_host_to_root.py
@@ -1,0 +1,68 @@
+import pytest
+from add_host_to_root import add_host_to_root
+
+
+def test_add_host_to_root_example():
+    """Test with the example given in the original file."""
+    original_css = """
+:root {}
+:root.dark {}
+html.dark, :root[data-bs-theme=dark] table.dataTable {}
+"""
+    expected_css = """
+:root, :host {}
+:root.dark, :host.dark {}
+html.dark, :root[data-bs-theme=dark] table.dataTable, :host[data-bs-theme=dark] table.dataTable {}
+"""
+    assert add_host_to_root(original_css) == expected_css
+
+
+def test_add_host_to_root_empty():
+    """Test with empty CSS content."""
+    assert add_host_to_root("") == ""
+
+
+def test_add_host_to_root_no_root():
+    """Test with CSS that doesn't contain :root selectors."""
+    css = "body { color: red; }"
+    assert add_host_to_root(css) == css
+
+
+def test_add_host_to_root_with_host_raises_error():
+    """Test that an error is raised if :host is already in the CSS."""
+    css = ":host { color: red; }"
+    with pytest.raises(ValueError):
+        add_host_to_root(css)
+
+
+def test_add_host_to_root_with_properties():
+    """Test with CSS rules that have properties."""
+    original_css = ":root { color: red; }"
+    expected_css = ":root, :host { color: red; }"
+    assert add_host_to_root(original_css) == expected_css
+
+
+def test_add_host_to_root_with_multiple_rules():
+    """Test with multiple CSS rules."""
+    original_css = """
+:root { color: red; }
+:root.dark { color: blue; }
+"""
+    expected_css = """
+:root, :host { color: red; }
+:root.dark, :host.dark { color: blue; }
+"""
+    assert add_host_to_root(original_css) == expected_css
+
+
+def test_add_host_to_root_complex_selectors():
+    """Test with complex selectors containing :root."""
+    original_css = """
+html.dark, :root[data-bs-theme=dark] table.dataTable { color: white; }
+:root[data-theme="light"] .element { background-color: white; }
+"""
+    expected_css = """
+html.dark, :root[data-bs-theme=dark] table.dataTable, :host[data-bs-theme=dark] table.dataTable { color: white; }
+:root[data-theme="light"] .element, :host[data-theme="light"] .element { background-color: white; }
+"""
+    assert add_host_to_root(original_css) == expected_css

--- a/packages/itables_anywidget/js/widget.css
+++ b/packages/itables_anywidget/js/widget.css
@@ -1,0 +1,1 @@
+@import 'dt_for_itables/dt_bundle.css';

--- a/packages/itables_anywidget/js/widget.ts
+++ b/packages/itables_anywidget/js/widget.ts
@@ -1,8 +1,5 @@
 import type { RenderContext } from "@anywidget/types";
-
-// DataTable and its css
 import { ITable, set_or_remove_dark_class } from 'dt_for_itables';
-import 'dt_for_itables/dt_bundle.css';
 
 /* Specifies attributes defined with traitlets in ../src/itables_anywidget/__init__.py */
 interface WidgetModel {

--- a/packages/itables_anywidget/package.json
+++ b/packages/itables_anywidget/package.json
@@ -1,7 +1,9 @@
 {
 	"scripts": {
 		"dev": "npm run build -- --sourcemap=inline --watch",
-		"build": "esbuild js/widget.ts --minify --format=esm --bundle --outdir=../../src/itables/widget/static",
+		"build:js": "esbuild js/widget.ts --format=esm --bundle --minify --outdir=../../src/itables/widget/static",
+		"build:css": "esbuild js/widget.css --bundle --minify --outdir=../../src/itables/widget/static",
+		"build": "npm run build:js && npm run build:css",
 		"typecheck": "tsc --noEmit"
 	},
 	"dependencies": {


### PR DESCRIPTION
This PR implements a change suggested by @mscolnick in this [comment](https://github.com/marimo-team/marimo/discussions/3192#discussioncomment-13225781).

While the change makes complete sense, and does set the `._css` attribute on the Jupyter widget as expected, it does not yet fix the issues seen in Marimo with v2.4.0, that is #383 and #387 .

Myles, sorry for asking, but the fact is that I know too little about CSS and shadow dom. Do you see what else I need to change on the `._css` field to make this work? In this simple example I would expect selected rows to appear in blue, but they don't:
![image](https://github.com/user-attachments/assets/7697de5f-7b29-41b1-a4a6-fad988e4339d)

Notes to myself:
- [ ] Determine whether the iframe approach is a workaround for #387
- [ ] Edit the `marimo.md` documentation page and remove the note about #383; add a note about #387