### PR TITLE
New option 'render_math'

### DIFF
--- a/docs/options/render_math.md
+++ b/docs/options/render_math.md
@@ -1,0 +1,40 @@
+---
+jupytext:
+  formats: docs///md:myst,docs/py///py:percent
+  notebook_metadata_filter: -jupytext.text_representation.jupytext_version
+  text_representation:
+    extension: .md
+    format_name: myst
+    format_version: 0.13
+kernelspec:
+  display_name: itables
+  language: python
+  name: itables
+---
+
+# Rendering Mathematical Formulae
+
+To render mathematical contents like equations in your DataFrame (rows or header), use the `render_math` option:
+
+```{code-cell}
+import pandas as pd
+
+import itables
+
+itables.init_notebook_mode()
+
+itables.show(
+    pd.DataFrame(
+        {
+            "$N_{\\text{event}}$": ["$\\alpha$", "$\\beta$", "$\\gamma$"] * 10,
+            "Value": [
+                "$0.8_{-0.1}^{+0.3}$",
+                "$3.2_{-0.4}^{+0.2}$",
+                "$-0.1_{-0.5}^{+0.8}$",
+            ]
+            * 10,
+        }
+    ),
+    render_math=True,
+)
+```

--- a/docs/py/options/render_math.py
+++ b/docs/py/options/render_math.py
@@ -1,0 +1,41 @@
+# ---
+# jupyter:
+#   jupytext:
+#     formats: docs///md:myst,docs/py///py:percent
+#     notebook_metadata_filter: -jupytext.text_representation.jupytext_version
+#     text_representation:
+#       extension: .py
+#       format_name: percent
+#       format_version: '1.3'
+#   kernelspec:
+#     display_name: itables
+#     language: python
+#     name: itables
+# ---
+
+# %% [markdown]
+# # Rendering Mathematical Formulae
+#
+# To render mathematical contents like equations in your DataFrame (rows or header), use the `render_math` option:
+
+# %%
+import pandas as pd
+
+import itables
+
+itables.init_notebook_mode()
+
+itables.show(
+    pd.DataFrame(
+        {
+            "$N_{\\text{event}}$": ["$\\alpha$", "$\\beta$", "$\\gamma$"] * 10,
+            "Value": [
+                "$0.8_{-0.1}^{+0.3}$",
+                "$3.2_{-0.4}^{+0.2}$",
+                "$-0.1_{-0.5}^{+0.8}$",
+            ]
+            * 10,
+        }
+    ),
+    render_math=True,
+)

--- a/packages/dt_for_itables/package-lock.json
+++ b/packages/dt_for_itables/package-lock.json
@@ -21,7 +21,8 @@
         "datatables.net-searchpanes-dt": "^2.3.3",
         "datatables.net-select-dt": "^3.0.0",
         "jquery": "^3.7.1",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "mathjax-full": "^3.2.2"
       },
       "devDependencies": {
         "esbuild": "^0.25.3"
@@ -467,6 +468,24 @@
       "integrity": "sha512-xzLEyKB50yqCUPUJkIsrVvoWNfFUbIZI+RspLWt8u+tIW/BetMBZtgV2LY/2o+tYH8dRvQ+eoPf3NdhQCcLE2w==",
       "license": "MIT"
     },
+    "node_modules/@xmldom/xmldom": {
+      "version": "0.9.8",
+      "resolved": "https://registry.npmjs.org/@xmldom/xmldom/-/xmldom-0.9.8.tgz",
+      "integrity": "sha512-p96FSY54r+WJ50FIOsCOjyj/wavs8921hG5+kVMmZgKcvIKxMXHTrjNJvRgWa/zuX3B6t2lijLNFaOyuxUH+2A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.6"
+      }
+    },
+    "node_modules/commander": {
+      "version": "13.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-13.1.0.tgz",
+      "integrity": "sha512-/rFeCpNJQbhSZjGVwO9RFV3xPqbnERS8MmIQzCtD/zl6gpJuV/bMLuN92oG3F7d8oDEHHRrujSXNUr8fpjntKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/core-util-is": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
@@ -696,6 +715,15 @@
         "@esbuild/win32-x64": "0.25.3"
       }
     },
+    "node_modules/esm": {
+      "version": "3.2.25",
+      "resolved": "https://registry.npmjs.org/esm/-/esm-3.2.25.tgz",
+      "integrity": "sha512-U1suiZ2oDVWv4zPO56S0NcR5QriEahGtdN2OR6FiOG4WJvcjBVFB0qI4+eKoWFH483PKGuLuu6V8Z4T5g63UVA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/immediate": {
       "version": "3.0.6",
       "resolved": "https://registry.npmjs.org/immediate/-/immediate-3.0.6.tgz",
@@ -741,6 +769,30 @@
         "immediate": "~3.0.5"
       }
     },
+    "node_modules/mathjax-full": {
+      "version": "3.2.2",
+      "resolved": "https://registry.npmjs.org/mathjax-full/-/mathjax-full-3.2.2.tgz",
+      "integrity": "sha512-+LfG9Fik+OuI8SLwsiR02IVdjcnRCy5MufYLi0C3TdMT56L/pjB0alMVGgoWJF8pN9Rc7FESycZB9BMNWIid5w==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "esm": "^3.2.25",
+        "mhchemparser": "^4.1.0",
+        "mj-context-menu": "^0.6.1",
+        "speech-rule-engine": "^4.0.6"
+      }
+    },
+    "node_modules/mhchemparser": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/mhchemparser/-/mhchemparser-4.2.1.tgz",
+      "integrity": "sha512-kYmyrCirqJf3zZ9t/0wGgRZ4/ZJw//VwaRVGA75C4nhE60vtnIzhl9J9ndkX/h6hxSN7pjg/cE0VxbnNM+bnDQ==",
+      "license": "Apache-2.0"
+    },
+    "node_modules/mj-context-menu": {
+      "version": "0.6.1",
+      "resolved": "https://registry.npmjs.org/mj-context-menu/-/mj-context-menu-0.6.1.tgz",
+      "integrity": "sha512-7NO5s6n10TIV96d4g2uDpG7ZDpIhMh0QNfGdJw/W47JswFcosz457wqz/b5sAKvl12sxINGFCn80NZHKwxQEXA==",
+      "license": "Apache-2.0"
+    },
     "node_modules/pako": {
       "version": "1.0.11",
       "resolved": "https://registry.npmjs.org/pako/-/pako-1.0.11.tgz",
@@ -780,6 +832,20 @@
       "integrity": "sha512-MATJdZp8sLqDl/68LfQmbP8zKPLQNV6BIZoIgrscFDQ+RsvK/BxeDQOgyxKKoh0y/8h3BqVFnCqQ/gd+reiIXA==",
       "license": "MIT"
     },
+    "node_modules/speech-rule-engine": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/speech-rule-engine/-/speech-rule-engine-4.1.2.tgz",
+      "integrity": "sha512-S6ji+flMEga+1QU79NDbwZ8Ivf0S/MpupQQiIC0rTpU/ZTKgcajijJJb1OcByBQDjrXCN1/DJtGz4ZJeBMPGJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@xmldom/xmldom": "0.9.8",
+        "commander": "13.1.0",
+        "wicked-good-xpath": "1.3.0"
+      },
+      "bin": {
+        "sre": "bin/sre"
+      }
+    },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
@@ -793,6 +859,12 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
+      "license": "MIT"
+    },
+    "node_modules/wicked-good-xpath": {
+      "version": "1.3.0",
+      "resolved": "https://registry.npmjs.org/wicked-good-xpath/-/wicked-good-xpath-1.3.0.tgz",
+      "integrity": "sha512-Gd9+TUn5nXdwj/hFsPVx5cuHHiF5Bwuc30jZ4+ronF1qHK5O7HD0sgmXWSEgwKquT3ClLoKPVbO6qGwVwLzvAw==",
       "license": "MIT"
     }
   }

--- a/packages/dt_for_itables/package.json
+++ b/packages/dt_for_itables/package.json
@@ -35,7 +35,8 @@
     "datatables.net-searchpanes-dt": "^2.3.3",
     "datatables.net-select-dt": "^3.0.0",
     "jquery": "^3.7.1",
-    "jszip": "^3.10.1"
+    "jszip": "^3.10.1",
+    "mathjax-full": "^3.2.2"
   },
   "devDependencies": {
     "esbuild": "^0.25.3"

--- a/packages/dt_for_itables/src/index.js
+++ b/packages/dt_for_itables/src/index.js
@@ -1,6 +1,14 @@
 import JSZip from 'jszip';
 import jQuery from 'jquery';
 
+// Add MathJax dependency
+import { mathjax } from 'mathjax-full/js/mathjax.js';
+import { TeX } from 'mathjax-full/js/input/tex.js';
+import { SVG } from 'mathjax-full/js/output/svg.js';
+import { liteAdaptor } from 'mathjax-full/js/adaptors/liteAdaptor.js';
+import { RegisterHTMLHandler } from 'mathjax-full/js/handlers/html.js';
+import { AllPackages } from 'mathjax-full/js/input/tex/AllPackages.js';
+
 import DataTable from 'datatables.net-dt';
 import 'datatables.net-dt/css/dataTables.dataTables.min.css';
 
@@ -80,9 +88,48 @@ function evalNestedKeys(obj, keys, context) {
     }
 }
 
+class MathJaxProcessor {
+    constructor() {
+        this.adaptor = liteAdaptor();
+        RegisterHTMLHandler(this.adaptor);
+
+        this.tex = new TeX({
+            packages: AllPackages,
+            inlineMath: [['$', '$'], ['\\(', '\\)']],
+            displayMath: [['$$', '$$'], ['\\[', '\\]']],
+            processEscapes: true
+        });
+
+        this.svg = new SVG({ fontCache: 'none' });
+        this.html = mathjax.document('', { InputJax: this.tex, OutputJax: this.svg });
+    }
+
+    convertLateXtoHTML(cellContent) {
+        if (!cellContent || typeof cellContent !== 'string') {
+            return cellContent;
+        }
+
+        // Process inline math: $...$
+        cellContent = cellContent.replace(/\$([^\$]+)\$/g, (match, latex) => {
+            const node = this.html.convert(latex, { display: false });
+            return this.adaptor.outerHTML(node);
+        });
+
+        // Process display math: $$...$$
+        cellContent = cellContent.replace(/\$\$([\s\S]+?)\$\$/g, (match, latex) => {
+            const node = this.html.convert(latex, { display: true });
+            return this.adaptor.outerHTML(node);
+        });
+
+        return cellContent;
+    }
+}
+
+const mathProcessor = new MathJaxProcessor();
+
 class ITable {
     constructor(table, itable_args) {
-        const { data, caption, classes, style, data_json, table_html, table_style, selected_rows, filtered_row_count, keys_to_be_evaluated, column_filters, text_in_header_can_be_selected, initComplete, downsampling_warning, ...dt_args } = itable_args;
+        const { data, caption, classes, style, data_json, table_html, table_style, selected_rows, filtered_row_count, keys_to_be_evaluated, column_filters, text_in_header_can_be_selected, initComplete, downsampling_warning, render_math = false, ...dt_args } = itable_args;
         if (data !== undefined) {
             throw new Error("The 'data' property is not allowed in dt_args.");
         }
@@ -94,6 +141,37 @@ class ITable {
         }
 
         this.filtered_row_count = filtered_row_count || 0;
+
+        // Store render_math flag for later use in drawCallback
+        this.render_math = render_math;
+
+        // Add drawCallback for math rendering
+        const originalDrawCallback = dt_args.drawCallback;
+        dt_args.drawCallback = (settings) => {
+            // Call original drawCallback if it exists
+            if (originalDrawCallback) {
+                originalDrawCallback.call(this.dt, settings);
+            }
+
+            // Process math in visible cells
+            if (this.render_math) {
+                jQuery(settings.nTable).find('tbody td').each((i, cell) => {
+                    const $cell = jQuery(cell);
+                    const cellText = $cell.text();
+
+                    // Only process cells that appear to contain LaTeX
+                    if (cellText.includes('$')) {
+                        // Store original HTML to avoid reprocessing
+                        if (!$cell.data('original-content')) {
+                            $cell.data('original-content', $cell.html());
+                        }
+
+                        // Replace with rendered math
+                        $cell.html(mathProcessor.convertLateXtoHTML($cell.data('original-content')));
+                    }
+                });
+            }
+        };
 
         if (text_in_header_can_be_selected || column_filters) {
             dt_args.initComplete = function (settings, json) {
@@ -161,7 +239,7 @@ class ITable {
 
         this.table = jQuery(table);
         if (table_html) {
-            this.table.html(table_html);
+            this.table.html(render_math ? mathProcessor.convertLateXtoHTML(table_html) : table_html);
         }
         if (classes) {
             classes.forEach(element => {

--- a/packages/itables_anywidget/package-lock.json
+++ b/packages/itables_anywidget/package-lock.json
@@ -29,7 +29,8 @@
 				"datatables.net-searchpanes-dt": "^2.3.3",
 				"datatables.net-select-dt": "^3.0.0",
 				"jquery": "^3.7.1",
-				"jszip": "^3.10.1"
+				"jszip": "^3.10.1",
+				"mathjax-full": "^3.2.2"
 			},
 			"devDependencies": {
 				"esbuild": "^0.25.3"

--- a/packages/itables_for_dash/package-lock.json
+++ b/packages/itables_for_dash/package-lock.json
@@ -48,7 +48,8 @@
         "datatables.net-searchpanes-dt": "^2.3.3",
         "datatables.net-select-dt": "^3.0.0",
         "jquery": "^3.7.1",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "mathjax-full": "^3.2.2"
       },
       "devDependencies": {
         "esbuild": "^0.25.3"

--- a/packages/itables_for_streamlit/package-lock.json
+++ b/packages/itables_for_streamlit/package-lock.json
@@ -35,7 +35,8 @@
         "datatables.net-searchpanes-dt": "^2.3.3",
         "datatables.net-select-dt": "^3.0.0",
         "jquery": "^3.7.1",
-        "jszip": "^3.10.1"
+        "jszip": "^3.10.1",
+        "mathjax-full": "^3.2.2"
       },
       "devDependencies": {
         "esbuild": "^0.25.3"

--- a/src/itables/options.py
+++ b/src/itables/options.py
@@ -71,6 +71,9 @@ setting this option to True.
 """
 allow_html: bool = False
 
+"""Render LaTeX expressions using MathJax."""
+render_math: bool = False
+
 """Optional table footer"""
 footer: bool = False
 

--- a/src/itables/typing.py
+++ b/src/itables/typing.py
@@ -95,6 +95,7 @@ class ITableOptions(DataTableOptions):
     maxColumns: NotRequired[int]
 
     allow_html: NotRequired[bool]
+    render_math: NotRequired[bool]
 
     table_id: NotRequired[str]
     dt_url: NotRequired[str]
@@ -136,6 +137,7 @@ class DTForITablesOptions(DataTableOptions):
 
     column_filters: NotRequired[Literal[False, "header", "footer"]]
     keys_to_be_evaluated: NotRequired[Sequence[Sequence[Union[int, str]]]]
+    render_math: NotRequired[bool]
 
     # These options are used in the HTML template
     # and don't reach the ITable JavaScript class


### PR DESCRIPTION
This is a tentative fix for #174 , but some work remains as including MathJax in `dt_for_itables` makes it huge - 2.3mb instead of  533.8kb.