### PR TITLE
Turn tomli into an optional dependency

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,12 @@
 ITables ChangeLog
 =================
 
+2.5.1 (2025-08-31)
+------------------
+
+**Changed**
+- `tomli` is an optional dependency of ITables
+
 2.5.0 (2025-08-31)
 ------------------
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -5,7 +5,8 @@ ITables ChangeLog
 ------------------
 
 **Changed**
-- `tomli` is an optional dependency of ITables
+- `tomli` is an optional dependency of ITables ([#436](https://github.com/mwouts/itables/pull/436))
+
 
 2.5.0 (2025-08-31)
 ------------------

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,10 +27,11 @@ classifiers = [
   "Typing :: Typed",
 ]
 requires-python = ">= 3.9"
-dependencies = ["IPython", "pandas", "numpy", "tomli;python_version<\"3.11\""]
+dependencies = ["IPython", "pandas", "numpy"]
 dynamic = ["version"]
 
 [project.optional-dependencies]
+config = ["tomli;python_version<\"3.11\""]
 polars = ["polars", "pyarrow"]
 check_type = ["typeguard>=4.4.1"]
 style = ["matplotlib"]
@@ -39,7 +40,7 @@ widget = ["anywidget", "traitlets"]
 streamlit = ["streamlit"]
 dash = ["dash"]
 shiny = ["shiny", "shinywidgets"]
-all = ["itables[polars,style,samples,widget,dash,shiny,streamlit,check_type]"]
+all = ["itables[config,polars,style,samples,widget,dash,shiny,streamlit,check_type]"]
 test = [
   "itables[all]",
   # Pytest

--- a/src/itables/config.py
+++ b/src/itables/config.py
@@ -70,8 +70,10 @@ def get_config_file(path: Path = Path.cwd()) -> Optional[Path]:
 
 
 def load_config_file(config_file: Path) -> ITableOptions:
-    if tomllib is None:
-        raise ImportError(f"Either tomllib or tomli is required to load {config_file}")
+        raise ImportError(
+            f"Either tomllib or tomli is required to load {config_file}. "
+            "Install with 'pip install itables[config]' to enable TOML config support."
+        )
 
     with open(config_file, "rb") as fp:
         try:

--- a/src/itables/config.py
+++ b/src/itables/config.py
@@ -16,7 +16,10 @@ from typing import Any, Optional, cast
 try:
     import tomllib
 except ImportError:
-    import tomli as tomllib  # pyright: ignore[reportMissingImports]
+    try:
+        import tomli as tomllib  # pyright: ignore[reportMissingImports]
+    except ImportError:
+        tomllib = None  # type: ignore[assignment]
 
 from platformdirs import user_config_path
 
@@ -50,6 +53,8 @@ def get_config_file(path: Path = Path.cwd()) -> Optional[Path]:
         config_file = parent / "pyproject.toml"
         if config_file.exists():
             with open(config_file, "rb") as fp:
+                if tomllib is None:
+                    continue
                 config = tomllib.load(fp)
                 if "tool" not in config or "itables" not in config["tool"]:
                     continue
@@ -65,6 +70,9 @@ def get_config_file(path: Path = Path.cwd()) -> Optional[Path]:
 
 
 def load_config_file(config_file: Path) -> ITableOptions:
+    if tomllib is None:
+        raise ImportError(f"Either tomllib or tomli is required to load {config_file}")
+
     with open(config_file, "rb") as fp:
         try:
             config = tomllib.load(fp)

--- a/src/itables/config.py
+++ b/src/itables/config.py
@@ -70,6 +70,7 @@ def get_config_file(path: Path = Path.cwd()) -> Optional[Path]:
 
 
 def load_config_file(config_file: Path) -> ITableOptions:
+    if tomllib is None:
         raise ImportError(
             f"Either tomllib or tomli is required to load {config_file}. "
             "Install with 'pip install itables[config]' to enable TOML config support."

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,3 +1,3 @@
 """ITables' version number"""
 
-__version__ = "2.5.0"
+__version__ = "2.5.1"


### PR DESCRIPTION
My attempt to add `tomli` as a (conditional) dependency to the conda package failed at https://github.com/mwouts/itables-feedstock/, so I will make it an optional dependency instead.