### PR TITLE
Format Polars objects using Polars' internal `x._s.get fmt()` method

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,11 @@
 ITables ChangeLog
 =================
 
-2.6.3.dev0 (2026-01-25)
+2.7.0.dev0 (2026-02-01)
 -----------------------
+
+**Changed**
+- Polars objects are displayed using Polars' internal method `x._s.get_fmt` ([#471](https://github.com/mwouts/itables/issues/471))
 
 **Fixed**
 - We have fixed an issue with `show_dtypes` for certain dataframes ([#480](https://github.com/mwouts/itables/issues/480))

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -545,6 +545,9 @@ def get_itable_arguments(
     warn_on_selected_rows_not_rendered = kwargs.pop(
         "warn_on_selected_rows_not_rendered", False
     )
+    warn_on_polars_get_fmt_not_found = kwargs.pop(
+        "warn_on_polars_get_fmt_not_found", True
+    )
     dt_args = cast(DTForITablesOptions, kwargs)
     if caption is not None:
         dt_args["caption"] = caption
@@ -597,8 +600,9 @@ def get_itable_arguments(
         dt_args["table_html"] = table_header
         dt_args["data_json"] = datatables_rows(
             df,
-            column_count,
+            column_count=column_count,
             warn_on_unexpected_types=warn_on_unexpected_types,
+            warn_on_polars_get_fmt_not_found=warn_on_polars_get_fmt_not_found,
             escape_html=allow_html is not True,
         )
     else:

--- a/src/itables/options.py
+++ b/src/itables/options.py
@@ -96,6 +96,9 @@ warn_on_unexpected_types: bool = True
 filtered by the downsampling?"""
 warn_on_selected_rows_not_rendered: bool = True
 
+"""Display a warning if the private Polars formatting method is not found"""
+warn_on_polars_get_fmt_not_found: bool = True
+
 """The DataTables URL for the connected mode"""
 dt_url: str = utils.UNPKG_DT_BUNDLE_URL
 

--- a/src/itables/typing.py
+++ b/src/itables/typing.py
@@ -194,6 +194,7 @@ class ITableOptions(DataTableOptions):
 
     warn_on_unexpected_types: NotRequired[bool]
     warn_on_selected_rows_not_rendered: NotRequired[bool]
+    warn_on_polars_get_fmt_not_found: NotRequired[bool]
     warn_on_undocumented_option: NotRequired[bool]
     warn_on_unexpected_option_type: NotRequired[bool]
     text_in_header_can_be_selected: NotRequired[bool]

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,4 +1,4 @@
 """ITables' version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "2.6.3.dev0"
+__version__ = "2.7.0.dev0"

--- a/tests/test_datatables_format.py
+++ b/tests/test_datatables_format.py
@@ -89,18 +89,10 @@ def df_and_expected(request):
             assert pl is not None
             return (pl.DataFrame({"x": [0, 1, None]}), [[0], [1], [None]])
     elif id == "float":
-        if lib == "pd":
-            assert pd is not None
-            return (
-                pd.DataFrame({"x": [0.2, math.pi, math.nan, -math.inf]}),
-                '[[0.2], [3.141593], ["___NaN___"], ["___-Infinity___"]]',
-            )
-        else:
-            assert pl is not None
-            return (
-                pl.DataFrame({"x": [0.2, math.pi, math.nan, -math.inf]}),
-                '[[0.2], [3.141592653589793], ["___NaN___"], ["___-Infinity___"]]',
-            )
+        return (
+            pd_or_pl.DataFrame({"x": [0.2, math.pi, math.nan, -math.inf]}),
+            '[[0.2], [3.141593], ["___NaN___"], ["___-Infinity___"]]',
+        )
     elif id == "str":
         return (pd_or_pl.DataFrame({"s": ["hi", '"hi"']}), [["hi"], ['"hi"']])
     elif id == "date":
@@ -127,7 +119,7 @@ def df_and_expected(request):
             assert pl is not None
             return (
                 pl.DataFrame({"t": [datetime(2022, 1, 1, 18, 5, 27), None]}),
-                [["2022-01-01 18:05:27.000000"], [None]],
+                [["2022-01-01 18:05:27"], [None]],
             )
     elif id == "datetime_with_tz":
         if lib == "pd":
@@ -159,7 +151,7 @@ def df_and_expected(request):
                 ).with_columns(
                     pl.col("t").dt.replace_time_zone(timezone("US/Eastern").zone)
                 ),
-                [["2022-01-01 18:05:27.000000-05:00"], [None]],
+                [["2022-01-01 18:05:27 EST"], [None]],
             )
     elif id == "timedelta":
         if lib == "pd":
@@ -172,7 +164,7 @@ def df_and_expected(request):
             assert pl is not None
             return (
                 pl.DataFrame({"dt": [timedelta(hours=1), None]}),
-                [["1:00:00"], [None]],
+                [["1h"], [None]],
             )
     elif id == "object_list":
         return (pd_or_pl.DataFrame({"list": [[1], [2, 3]]}), [["[1]"], ["[2, 3]"]])
@@ -187,7 +179,7 @@ def df_and_expected(request):
             assert pl is not None
             return (
                 pl.DataFrame({"dict": [{"a": 1, "b": None}, {"b": [1, 2]}]}),
-                [["{'a': 1, 'b': None}"], ["{'a': None, 'b': [1, 2]}"]],
+                [["{1,null}"], ["{null,[1, 2]}"]],
             )
     elif id == "df_with_named_column_axis":
         if lib == "pl":
@@ -305,7 +297,7 @@ def test_encode_mixed_contents_polars():
     )
     assert (
         datatables_rows(df)
-        == "[[1666767918216000000, 1699300000000, 0.9510565400123596, -0.30901700258255005]]"
+        == "[[1666767918216000000, 1699300000000, 0.951057, -0.309017]]"
     )
 
 
@@ -317,10 +309,114 @@ def test_polars_float_formatting():
         pytest.skip("polars is not installed")
 
     df = pl.DataFrame({"float": [math.pi, math.pi * 1e12]})
-    assert datatables_rows(df) == "[[3.141592653589793], [3141592653589.793]]"
+    assert datatables_rows(df) == "[[3.141593], [3141600000000.0]]"
 
-    with pl.Config(float_precision=6):
-        assert datatables_rows(df) == "[[3.141593], [3141592653589.793]]"
+    with pl.Config(float_precision=12):
+        assert datatables_rows(df) == "[[3.14159265359], [3141592653590.0]]"
+
+
+def test_polars_array_float_formatting():
+    """Test that Polars float_precision config applies to Array[Float64] columns"""
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("polars is not installed")
+
+    # Test with Array[Float64]
+    df = pl.DataFrame(
+        {"array_col": [[1.234567890123456, 2.345678901234567, math.pi]]},
+        schema={"array_col": pl.Array(pl.Float64, 3)},
+    )
+
+    # Default formatting - Polars default precision (6 decimal places)
+    result = datatables_rows(df)
+    assert "[1.234568, 2.345679, 3.141593]" in result
+
+    # With precision=2
+    with pl.Config(float_precision=2):
+        result = datatables_rows(df)
+        assert "[1.23, 2.35, 3.14]" in result
+
+    # With precision=10
+    with pl.Config(float_precision=10):
+        result = datatables_rows(df)
+        assert "[1.2345678901, 2.3456789012, 3.1415926536]" in result
+
+
+def test_polars_list_float_formatting():
+    """Test that Polars float_precision config applies to List[Float64] columns"""
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("polars is not installed")
+
+    # Test with List[Float64]
+    df = pl.DataFrame(
+        {
+            "list_col": [
+                [1.234567890123456, 2.345678901234567, math.pi],
+                [4.5, 6.7],
+            ]
+        }
+    )
+
+    # Default formatting - Polars default precision (6 decimal places)
+    result = datatables_rows(df)
+    assert "[1.234568, 2.345679, 3.141593]" in result
+    assert "[4.5, 6.7]" in result
+
+    # With precision=2
+    with pl.Config(float_precision=2):
+        result = datatables_rows(df)
+        assert "[1.23, 2.35, 3.14]" in result
+        # Note: 4.5 and 6.7 become 4.50 and 6.70 with precision=2
+        assert "[4.50, 6.70]" in result
+
+    # With precision=10
+    with pl.Config(float_precision=10):
+        result = datatables_rows(df)
+        assert "[1.2345678901, 2.3456789012, 3.1415926536]" in result
+        assert "[4.5000000000, 6.7000000000]" in result
+
+
+def test_polars_array_list_with_non_finite_floats():
+    """Test that non-finite floats in arrays/lists are properly escaped"""
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("polars is not installed")
+
+    # Test with Array containing NaN, Inf, -Inf
+    df_array = pl.DataFrame(
+        {"array_col": [[1.5, math.nan, math.inf, -math.inf, 2.5]]},
+        schema={"array_col": pl.Array(pl.Float64, 5)},
+    )
+    result = datatables_rows(df_array)
+    assert result == '[["[1.5, NaN, \\u2026 2.5]"]]'
+
+    # Test with List containing NaN, Inf
+    df_list = pl.DataFrame({"list_col": [[1.5, math.nan, math.inf], [-math.inf, 2.5]]})
+    result = datatables_rows(df_list)
+    assert result == '[["[1.5, NaN, inf]"], ["[-inf, 2.5]"]]'
+
+
+def test_polars_list_with_none_values():
+    """Test that None values in list columns are handled correctly"""
+    try:
+        import polars as pl
+    except ImportError:
+        pytest.skip("polars is not installed")
+
+    df = pl.DataFrame({"list_col": [[1.5, 2.5], None, [3.5]]})
+
+    # Default formatting
+    result = datatables_rows(df)
+    assert result == '[["[1.5, 2.5]"], [null], ["[3.5]"]]'
+
+    # With precision - Polars adds trailing zeros to match precision
+    with pl.Config(float_precision=2):
+        result = datatables_rows(df)
+        assert result == '[["[1.50, 2.50]"], [null], ["[3.50]"]]'
 
 
 def test_show_dtypes_pandas():


### PR DESCRIPTION
Closes #471 

TODO:
- [x] Remove the additional string added to the "enum" types
- [ ] Get a proper formatting for `pl.DataFrame({"float": [math.pi, math.pi * 1e12]})` (get `3.1416e12` for the second row, not `3141600000000` as currently) => will be done at #483 