### PR TITLE
Test NaN and None in Polars

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ ITables ChangeLog
 **Fixed**
 - We have fixed an issue with `show_dtypes` for certain dataframes ([#480](https://github.com/mwouts/itables/issues/480))
 
+**Added**
+- We have added a test to ensure that `float("nan")` entries in a Polars DataFrame are displayed as `NaN`. However, `None` entries are displayed as `null`, e.g. as an empty cell.
+
 
 2.6.2 (2025-12-26)
 ------------------

--- a/tests/test_sample_polars_dfs.py
+++ b/tests/test_sample_polars_dfs.py
@@ -141,3 +141,20 @@ def test_format_polars_series(series_name, series):
 @pytest.mark.parametrize("series_name,series", get_dict_of_test_series().items())
 def test_show_test_series(series_name, series, connected, monkeypatch):
     show(series, connected=connected)
+
+
+def test_polars_df_with_nan_and_none():
+    df = pl.DataFrame(
+        {
+            "A": [1, 2, None, 4],
+            "B": [0.1, None, float("nan"), 0.4],
+            "C": ["x", None, "z", "w"],
+        }
+    )
+    assert df.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
+    dt_args = get_itable_arguments(df)
+    assert "data_json" in dt_args
+    assert (
+        dt_args["data_json"]
+        == '[[1, 0.1, "x"], [2, null, null], [null, "___NaN___", "z"], [4, 0.4, "w"]]'
+    )


### PR DESCRIPTION
This PR documents how `NaN` and `None` currently appears in ITables v2.6.3dev. 

None is encoded as `null` which leads to an empty cell, while `NaN` appears as such:
<img width="196" height="573" alt="image" src="https://github.com/user-attachments/assets/49ee6c86-f6b2-4cf2-9896-3f2f93fa971f" />

In a later release we might make the `null` more explicit.