### PR TITLE
Add "compact" to the default classes

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,13 +1,14 @@
 ITables ChangeLog
 =================
 
-2.7.0rc0 (2026-02-01)
------------------------
+2.7.0rc1 (2026-02-01)
+---------------------
 
 **Changed**
 - Floats are formatted using the underlying dataframe formatter when `format_floats_in_python` is `"auto"` (the default). Set that option `False` if you want to format the values in JS directly ([#483](https://github.com/mwouts/itables/issues/483)).
 - Polars objects are displayed using Polars' internal method `x._s.get_fmt` ([#471](https://github.com/mwouts/itables/issues/471))
 - We have updated `dt_for_itables` to the latest version of `datatables.net-dt==2.3.7` ([#485](https://github.com/mwouts/itables/issues/485))
+- The default look of ITables is more compact. Create an `itables.toml` configuration file with just `classes = ["display", "nowrap"]` to revert the change locally.
 
 
 **Fixed**

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -30,9 +30,9 @@ The configuration file is identified using `get_config_file` from [`itables.conf
 
 ## Example configuration
 
-A simple `itables.toml` configuration file that makes the tables a bit more [compact](options/classes.md) looks like this:
+A simple `itables.toml` configuration file that makes the tables less [compact](options/classes.md) looks like this:
 ```
-classes = ["display", "nowrap", "compact"]
+classes = ["display", "nowrap"]
 ```
 
 If you want the Excel export button on each table, add this:

--- a/docs/options/classes.md
+++ b/docs/options/classes.md
@@ -14,9 +14,9 @@ kernelspec:
 
 # Classes
 
-Select how your table looks like with the `classes` argument (defaults to `"display nowrap"`) of the `show` function, or by changing `itables.options.classes`.
+Select how your table looks like with the `classes` argument (defaults to `"display nowrap compact"`) of the `show` function, or by changing `itables.options.classes`.
 
-Add `"compact"` if you want a denser table:
+Remove `"compact"` if you want a less dense table:
 
 ```{code-cell} ipython3
 :tags: [full-width]
@@ -27,7 +27,7 @@ itables.init_notebook_mode()
 
 df = itables.sample_dfs.get_countries()
 
-itables.show(df, classes="display nowrap compact")
+itables.show(df, classes="display nowrap")
 ```
 
 Remove `"nowrap"` if you want the cell content to be wrapped:
@@ -35,7 +35,7 @@ Remove `"nowrap"` if you want the cell content to be wrapped:
 ```{code-cell} ipython3
 :tags: [full-width]
 
-itables.show(df, classes="display")
+itables.show(df, classes="display compact")
 ```
 
 [More options](https://datatables.net/manual/styling/classes#Table-classes) like `"cell-border"` are available:
@@ -43,12 +43,12 @@ itables.show(df, classes="display")
 ```{code-cell} ipython3
 :tags: [full-width]
 
-itables.show(df, classes="display nowrap cell-border")
+itables.show(df, classes="display nowrap compact cell-border")
 ```
 
 ```{tip}
 You can change the default for all your notebooks and apps by creating an `itables.toml` [configuration file](../configuration.md) in the current or a parent directory, with e.g. this content:
 ~~~
-classes = ["display", "nowrap", "compact"]
+classes = ["display", "nowrap"]
 ~~~
 ```

--- a/docs/py/configuration.py
+++ b/docs/py/configuration.py
@@ -32,9 +32,9 @@
 #
 # ## Example configuration
 #
-# A simple `itables.toml` configuration file that makes the tables a bit more [compact](options/classes.md) looks like this:
+# A simple `itables.toml` configuration file that makes the tables less [compact](options/classes.md) looks like this:
 # ```
-# classes = ["display", "nowrap", "compact"]
+# classes = ["display", "nowrap"]
 # ```
 #
 # If you want the Excel export button on each table, add this:

--- a/docs/py/options/classes.py
+++ b/docs/py/options/classes.py
@@ -17,9 +17,9 @@
 # %% [markdown]
 # # Classes
 #
-# Select how your table looks like with the `classes` argument (defaults to `"display nowrap"`) of the `show` function, or by changing `itables.options.classes`.
+# Select how your table looks like with the `classes` argument (defaults to `"display nowrap compact"`) of the `show` function, or by changing `itables.options.classes`.
 #
-# Add `"compact"` if you want a denser table:
+# Remove `"compact"` if you want a less dense table:
 
 # %% tags=["full-width"]
 import itables
@@ -28,24 +28,24 @@ itables.init_notebook_mode()
 
 df = itables.sample_dfs.get_countries()
 
-itables.show(df, classes="display nowrap compact")
+itables.show(df, classes="display nowrap")
 
 # %% [markdown]
 # Remove `"nowrap"` if you want the cell content to be wrapped:
 
 # %% tags=["full-width"]
-itables.show(df, classes="display")
+itables.show(df, classes="display compact")
 
 # %% [markdown]
 # [More options](https://datatables.net/manual/styling/classes#Table-classes) like `"cell-border"` are available:
 
 # %% tags=["full-width"]
-itables.show(df, classes="display nowrap cell-border")
+itables.show(df, classes="display nowrap compact cell-border")
 
 # %% [markdown]
 # ```{tip}
 # You can change the default for all your notebooks and apps by creating an `itables.toml` [configuration file](../configuration.md) in the current or a parent directory, with e.g. this content:
 # ~~~
-# classes = ["display", "nowrap", "compact"]
+# classes = ["display", "nowrap"]
 # ~~~
 # ```

--- a/src/itables/options.py
+++ b/src/itables/options.py
@@ -45,7 +45,7 @@ show_df_type: bool = False
 The default classes.
 See https://mwouts.github.io/itables/options/classes.html
 """
-classes: Union[str, Sequence[str]] = "display nowrap"
+classes: Union[str, Sequence[str]] = "display nowrap compact"
 
 """
 The default table style.

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,4 +1,4 @@
 """ITables' version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "2.7.0rc0"
+__version__ = "2.7.0rc1"


### PR DESCRIPTION
This PR makes the default rendering of tables more compact, see https://mwouts.github.io/itables/options/classes.html