### PR TITLE
`pl.String`s don't need formatting

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -6,7 +6,7 @@ ITables ChangeLog
 
 **Changed**
 - Floats are formatted using the underlying dataframe formatter when `format_floats_in_python` is `"auto"` (the default). Set that option `False` if you want to format the values in JS directly ([#483](https://github.com/mwouts/itables/issues/483)).
-- Polars objects are displayed using Polars' internal method `x._s.get_fmt` ([#471](https://github.com/mwouts/itables/issues/471))
+- Float and complex Polars objects are displayed using Polars' internal method `x._s.get_fmt` ([#471](https://github.com/mwouts/itables/issues/471))
 - We have updated `dt_for_itables` to the latest version of `datatables.net-dt==2.3.7` ([#485](https://github.com/mwouts/itables/issues/485))
 - The default look of ITables is more compact. Create an `itables.toml` configuration file with just `classes = ["display", "nowrap"]` to revert the change locally.
 

--- a/tests/test_datatables_format.py
+++ b/tests/test_datatables_format.py
@@ -556,3 +556,24 @@ def test_render_in_columndefs_deactivates_python_float_formatting_pandas():
         columnDefs=columnDefs,
     )
     assert float_columns == set()
+
+
+@pytest.mark.parametrize("dataframe_library", ["pandas", "polars"])
+def test_long_strings_are_not_truncated(dataframe_library: str):
+    """Test that long strings are passed verbatim to itables for Pandas"""
+    pd_or_pl = pytest.importorskip(dataframe_library)
+
+    # Create a dataframe with a long string that exceeds the typical truncation length
+    long_string = (
+        "This is a very long string that should not be truncated by itables formatting. "
+        * 50
+    )
+    df = pd_or_pl.DataFrame({"text": [long_string]})
+
+    # Get the formatted rows
+    result = datatables_rows(df)
+
+    # The result should contain the full string
+    assert (
+        long_string in result
+    ), f"Long string was truncated in {dataframe_library} dataframe"

--- a/tests/test_sample_polars_dfs.py
+++ b/tests/test_sample_polars_dfs.py
@@ -186,12 +186,12 @@ def test_polars_df_with_nan_and_none():
             "C": ["x", None, "z", "w"],
         }
     )
-    assert df.dtypes == [pl.Int64, pl.Float64, pl.Utf8]
+    assert df.dtypes == [pl.Int64, pl.Float64, pl.String]
     dt_args = get_itable_arguments(df, format_floats_in_python=False)
     assert "data_json" in dt_args
     assert (
         dt_args["data_json"] == '[[1, 0.1, "x"], '
-        '[2, null, "null"], '
+        "[2, null, null], "
         '[null, "___NaN___", "z"], '
         '[4, 0.4, "w"]]'
     )
@@ -200,7 +200,7 @@ def test_polars_df_with_nan_and_none():
     assert "data_json" in dt_args
     assert (
         dt_args["data_json"] == '[[1, {"display": "0.1", "sort": 0.1}, "x"], '
-        '[2, {"display": "null", "sort": null}, "null"], '
+        '[2, {"display": "null", "sort": null}, null], '
         '[null, {"display": "NaN", "sort": "___NaN___"}, "z"], '
         '[4, {"display": "0.4", "sort": 0.4}, "w"]]'
     )


### PR DESCRIPTION
This PR fixes long strings being truncated in Polars DataFrames in ITables v2.7.0rc1