### PR TITLE
sorted JSON keys for deterministic HTML tables

### DIFF
--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -988,8 +988,8 @@ def html_table_from_template(
     assert "style" in kwargs
     kwargs["style"] = get_expanded_style(kwargs["style"])
 
-    # Export the DT args to JSON
-    dt_args = json.dumps(kwargs)
+    # Export the DT args to JSON, sort keys for reproducible output
+    dt_args = json.dumps(kwargs, sort_keys=True)
     output = replace_value(
         output, "let dt_args = {};", "let dt_args = {};".format(dt_args)
     )


### PR DESCRIPTION
This small edit addresses #502 . 

I search the src/ folder and this is the only place where this specific kind (dict to json) of undeterministic behavior is possible. The only other `json.dumps()` is 
this part of `datatables_format.datatables_rows()`, in which a list is exported:

https://github.com/mwouts/itables/blob/d65cbb174e1b06f8c0de6123228b1d47b54e0472/src/itables/datatables_format.py#L252-L258