### PR TITLE
Version 2.8.2

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -88,6 +88,7 @@ jobs:
         uses: github/codeql-action/analyze@7188fc363630916deb702c7fdcf4e481b751f97a # v4.37.1
 
   pytest:
+    needs: build-wheel
     strategy:
       fail-fast: false
       matrix:
@@ -113,16 +114,21 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Set up Node
-        uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-
       - name: Set up Python ${{ matrix.python-version }}
         uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
         with:
           python-version: ${{ matrix.python-version }}
 
+      - name: Download the pre-built wheel
+        uses: actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131 # v7
+        with:
+          name: itables-wheel
+          path: dist
+
       - name: Install a development version of 'itables'
-        run: pip install -e .[test-all]
+        # Install from the wheel built once in build-wheel, instead of rebuilding
+        # the JS bundle (via pip install -e .) in every matrix job.
+        run: pip install "$(ls dist/itables-*.whl)[test-all]"
 
       - name: Install pandas latest
         if: matrix.pandas-version == 'latest'
@@ -181,7 +187,7 @@ jobs:
         run: pixi run python -m ipykernel install --name itables --user
 
       - name: Test with pytest
-        run: pixi run pytest --cov=./ --cov-report=xml
+        run: pixi run pytest -n auto --cov=./ --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
@@ -190,6 +196,9 @@ jobs:
           verbose: true
 
   pytest-pixi-updated:
+    # This job re-tests against updated pixi/conda-forge dependencies. It overlaps
+    # with the weekly `schedule` trigger, so skip it on PRs to keep them faster.
+    if: github.event_name != 'pull_request'
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -214,7 +223,7 @@ jobs:
         run: pixi run python -m ipykernel install --name itables --user
 
       - name: Test with pytest
-        run: pixi run pytest --cov=./ --cov-report=xml
+        run: pixi run pytest -n auto --cov=./ --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7
@@ -278,7 +287,7 @@ jobs:
         run: pixi run -e ${{ matrix.environment }} python -m ipykernel install --name itables --user
 
       - name: Test with pytest in ${{ matrix.environment }}
-        run: pixi run -e ${{ matrix.environment }} pytest --cov=./ --cov-report=xml
+        run: pixi run -e ${{ matrix.environment }} pytest -n auto --cov=./ --cov-report=xml
 
       - name: Upload coverage
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -7,6 +7,9 @@ Unreleased
 **Added**
 - We have added a `css` argument to `show` (and a matching `itables.options.css`) to inject custom CSS. Unlike `display(HTML(f"<style>{css}</style>"))`, this CSS is embedded in the output of every table, so it does not depend on that separate cell's output being rendered - some notebook front-ends (e.g. VS Code) defer rendering outputs that are scrolled out of view, so a standalone CSS cell may not take effect until it becomes visible ([#572](https://github.com/mwouts/itables/issues/572)).
 
+**Changed**
+- We have sped up the CI: the `pytest` matrix jobs now install the wheel built once by `build-wheel` instead of each rebuilding the JS bundle from source, tests now run in parallel with `pytest-xdist`, and `pytest-pixi-updated` (which overlaps with the weekly scheduled run) is skipped on pull requests.
+
 **Fixed**
 - We have fixed the dark mode detection so that it also reacts to theme changes that happen *after* the table has been rendered, e.g. when the user switches the Jupyter Lab or VS Code theme ([#576](https://github.com/mwouts/itables/issues/576)).
 - We have fixed the dark mode detection in offline mode ([#564](https://github.com/mwouts/itables/issues/564)).

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,8 +1,8 @@
 ITables ChangeLog
 =================
 
-Unreleased
-----------
+2.8.2 (2026-07-19)
+------------------
 
 **Added**
 - We have added a `css` argument to `show` (and a matching `itables.options.css`) to inject custom CSS. Unlike `display(HTML(f"<style>{css}</style>"))`, this CSS is embedded in the output of every table, so it does not depend on that separate cell's output being rendered - some notebook front-ends (e.g. VS Code) defer rendering outputs that are scrolled out of view, so a standalone CSS cell may not take effect until it becomes visible ([#572](https://github.com/mwouts/itables/issues/572)).

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,4 +1,4 @@
 """ITables' version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "2.8.1"
+__version__ = "2.8.2"


### PR DESCRIPTION
**Added**
- We have added a `css` argument to `show` (and a matching `itables.options.css`) to inject custom CSS. Unlike `display(HTML(f"<style>{css}</style>"))`, this CSS is embedded in the output of every table, so it does not depend on that separate cell's output being rendered - some notebook front-ends (e.g. VS Code) defer rendering outputs that are scrolled out of view, so a standalone CSS cell may not take effect until it becomes visible ([#572](https://github.com/mwouts/itables/issues/572)).

**Changed**
- We have sped up the CI: the `pytest` matrix jobs now install the wheel built once by `build-wheel` instead of each rebuilding the JS bundle from source, tests now run in parallel with `pytest-xdist`, and `pytest-pixi-updated` (which overlaps with the weekly scheduled run) is skipped on pull requests.

**Fixed**
- We have fixed the dark mode detection so that it also reacts to theme changes that happen *after* the table has been rendered, e.g. when the user switches the Jupyter Lab or VS Code theme ([#576](https://github.com/mwouts/itables/issues/576)).
- We have fixed the dark mode detection in offline mode ([#564](https://github.com/mwouts/itables/issues/564)).
- We have fixed the dark mode detection in Quarto documents ([#536](https://github.com/mwouts/itables/issues/536)).
- We have fixed the misaligned ColumnControl search dropdown (e.g. `columnControl={"content": ["searchDropdown"]}`) ([#536](https://github.com/mwouts/itables/issues/536)).
- The `dash` version used to generate `src/itables_for_dash/ITable.py` is now pinned to `dash==4.4.0` to avoid jitter in `ITable.py`.

**Security**
- We have added [zizmor](https://zizmor.sh/) to our CI to scan the GitHub Actions workflows for security issues. All actions are now pinned to a commit SHA, checkout steps no longer persist credentials, jobs use least-privilege permissions, and we fixed a code-injection risk in the PR-comment workflow where untrusted pull request metadata was interpolated directly into a `github-script` template.