### PR TITLE
Use a simple python3 kernel for the docs

### DIFF
--- a/.github/workflows/publish-book.yml
+++ b/.github/workflows/publish-book.yml
@@ -29,36 +29,25 @@ jobs:
       with:
         persist-credentials: false
 
-    - name: Set up Node
-      uses: actions/setup-node@249970729cb0ef3589644e2896645e5dc5ba9c38 # v6
-
-    - name: Set up Python 3.11
-      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1 # v6
+    - name: Setup Pixi
+      uses: prefix-dev/setup-pixi@a09b6247153796b190642a2b53fac4241043cf6f # v0.10.0
       with:
-        python-version: 3.11
-
-    - name: Install dependencies
-      run: |
-        pip install 'jupyter-book<2' sphinxext-rediraffe
-        pip install matplotlib  # Pandas style
-        pip install .[all]
-
-    - name: Create a kernel
-      run: |
-        pip install ipykernel
-        python -m ipykernel install --name itables --user
+        pixi-version: latest
+        locked: false
+        frozen: true
+        cache: true
 
     - name: Install Quarto
       uses: quarto-dev/quarto-actions/setup@8a96df13519ee81fd526f2dfca5962811136661b # v2
 
     - name: Render the quarto examples
       run: |
-        for qmd_file in `ls docs/quarto/*.qmd`; do quarto render ${qmd_file}; done
+        for qmd_file in `ls docs/quarto/*.qmd`; do pixi run -e docs quarto render ${qmd_file}; done
 
     # Build the book
     - name: Build the book
       run: |
-        jupyter-book build docs
+        pixi run -e docs jupyter-book build docs
 
     # Upload the book's HTML as an artifact
     - name: Upload artifact

--- a/docs/apps/dash.md
+++ b/docs/apps/dash.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Dash

--- a/docs/apps/html.md
+++ b/docs/apps/html.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/apps/marimo.md
+++ b/docs/apps/marimo.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Marimo

--- a/docs/apps/notebook.md
+++ b/docs/apps/notebook.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/apps/widget.md
+++ b/docs/apps/widget.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -9,6 +9,7 @@ Unreleased
 
 **Changed**
 - We have further sped up the CI: the conda package is now built with [rattler-build](https://rattler.build/) instead of `conda-build`, and dependencies in the `pytest` matrix are now installed with [uv](https://docs.astral.sh/uv/) instead of `pip`.
+- We now use a standard `python3` kernel for the documentation - this removes the need for a custom kernel.
 
 
 2.8.2 (2026-07-19)

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Configuration

--- a/docs/contributing.md
+++ b/docs/contributing.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/css.md
+++ b/docs/css.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/custom_extensions.md
+++ b/docs/custom_extensions.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Custom Extensions

--- a/docs/dark_mode.md
+++ b/docs/dark_mode.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Dark Themes

--- a/docs/developing.md
+++ b/docs/developing.md
@@ -77,12 +77,7 @@ This uses the dedicated `build` pixi environment, which pins `hatch` and
 
 The `itables` documentation uses [Jupyter Book](https://jupyterbook.org/).
 
-To build the documentation locally,
-you need to create a Jupyter kernel named `itables` with
-```shell
-python -m ipykernel install --name itables --user
-```
-Then you can build the documentation with
+Build the documentation with:
 ```shell
 pixi run -e docs jupyter book build docs
 ```

--- a/docs/downsampling.md
+++ b/docs/downsampling.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/markdown_preview.md
+++ b/docs/fallbacks/markdown_preview.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/markdown_preview_pandas_dataframes.md
+++ b/docs/fallbacks/markdown_preview_pandas_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/markdown_preview_polars_dataframes.md
+++ b/docs/fallbacks/markdown_preview_polars_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/static_preview.md
+++ b/docs/fallbacks/static_preview.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/static_preview_pandas_dataframes.md
+++ b/docs/fallbacks/static_preview_pandas_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/fallbacks/static_preview_polars_dataframes.md
+++ b/docs/fallbacks/static_preview_polars_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/formatting.md
+++ b/docs/formatting.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/options/allow_html.md
+++ b/docs/options/allow_html.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/options/buttons.md
+++ b/docs/options/buttons.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Buttons

--- a/docs/options/caption.md
+++ b/docs/options/caption.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Caption

--- a/docs/options/classes.md
+++ b/docs/options/classes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Classes

--- a/docs/options/col_reorder.md
+++ b/docs/options/col_reorder.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Col Reorder

--- a/docs/options/column_control.md
+++ b/docs/options/column_control.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Column Control

--- a/docs/options/column_defs.md
+++ b/docs/options/column_defs.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/options/column_filters.md
+++ b/docs/options/column_filters.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Column Filters

--- a/docs/options/colvis.md
+++ b/docs/options/colvis.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Column Visibility

--- a/docs/options/fixed_columns.md
+++ b/docs/options/fixed_columns.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Fixed Columns

--- a/docs/options/fixed_header.md
+++ b/docs/options/fixed_header.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Fixed Header

--- a/docs/options/footer.md
+++ b/docs/options/footer.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Footer

--- a/docs/options/keys.md
+++ b/docs/options/keys.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Keys

--- a/docs/options/layout.md
+++ b/docs/options/layout.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Layout

--- a/docs/options/length_menu.md
+++ b/docs/options/length_menu.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Length Menu

--- a/docs/options/options.md
+++ b/docs/options/options.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Options

--- a/docs/options/order.md
+++ b/docs/options/order.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Order

--- a/docs/options/paging.md
+++ b/docs/options/paging.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Paging

--- a/docs/options/row_group.md
+++ b/docs/options/row_group.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/options/scroll_x.md
+++ b/docs/options/scroll_x.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Horizontal Scroll

--- a/docs/options/scroll_y.md
+++ b/docs/options/scroll_y.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Vertical Scroll

--- a/docs/options/search.md
+++ b/docs/options/search.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Search

--- a/docs/options/search_builder.md
+++ b/docs/options/search_builder.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Search Builder

--- a/docs/options/search_panes.md
+++ b/docs/options/search_panes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Search Panes

--- a/docs/options/select.md
+++ b/docs/options/select.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Select

--- a/docs/options/show_df_type.md
+++ b/docs/options/show_df_type.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Show DataFrame or Series Type

--- a/docs/options/show_dtypes.md
+++ b/docs/options/show_dtypes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Show dtypes

--- a/docs/options/show_index.md
+++ b/docs/options/show_index.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Show Index

--- a/docs/options/state_save.md
+++ b/docs/options/state_save.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # State Save

--- a/docs/options/style.md
+++ b/docs/options/style.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Style

--- a/docs/options/text_in_header_can_be_selected.md
+++ b/docs/options/text_in_header_can_be_selected.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Select Text in Header

--- a/docs/other_dataframes.md
+++ b/docs/other_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Other DataFrames

--- a/docs/pandas_dataframes.md
+++ b/docs/pandas_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Pandas dataframes

--- a/docs/pandas_style.md
+++ b/docs/pandas_style.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/polars_dataframes.md
+++ b/docs/polars_dataframes.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 # Polars dataframes

--- a/docs/py/apps/dash.py
+++ b/docs/py/apps/dash.py
@@ -8,9 +8,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/apps/html.py
+++ b/docs/py/apps/html.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/apps/marimo.py
+++ b/docs/py/apps/marimo.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/apps/notebook.py
+++ b/docs/py/apps/notebook.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/apps/widget.py
+++ b/docs/py/apps/widget.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/configuration.py
+++ b/docs/py/configuration.py
@@ -8,9 +8,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/contributing.py
+++ b/docs/py/contributing.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/css.py
+++ b/docs/py/css.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/custom_extensions.py
+++ b/docs/py/custom_extensions.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/dark_mode.py
+++ b/docs/py/dark_mode.py
@@ -8,9 +8,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/downsampling.py
+++ b/docs/py/downsampling.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/markdown_preview.py
+++ b/docs/py/fallbacks/markdown_preview.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/markdown_preview_pandas_dataframes.py
+++ b/docs/py/fallbacks/markdown_preview_pandas_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/markdown_preview_polars_dataframes.py
+++ b/docs/py/fallbacks/markdown_preview_polars_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/static_preview.py
+++ b/docs/py/fallbacks/static_preview.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/static_preview_pandas_dataframes.py
+++ b/docs/py/fallbacks/static_preview_pandas_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/fallbacks/static_preview_polars_dataframes.py
+++ b/docs/py/fallbacks/static_preview_polars_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/formatting.py
+++ b/docs/py/formatting.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/options/allow_html.py
+++ b/docs/py/options/allow_html.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/options/buttons.py
+++ b/docs/py/options/buttons.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/caption.py
+++ b/docs/py/options/caption.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/classes.py
+++ b/docs/py/options/classes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/col_reorder.py
+++ b/docs/py/options/col_reorder.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/column_control.py
+++ b/docs/py/options/column_control.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/column_defs.py
+++ b/docs/py/options/column_defs.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/options/column_filters.py
+++ b/docs/py/options/column_filters.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/colvis.py
+++ b/docs/py/options/colvis.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/fixed_columns.py
+++ b/docs/py/options/fixed_columns.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/fixed_header.py
+++ b/docs/py/options/fixed_header.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/footer.py
+++ b/docs/py/options/footer.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/keys.py
+++ b/docs/py/options/keys.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/layout.py
+++ b/docs/py/options/layout.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/length_menu.py
+++ b/docs/py/options/length_menu.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/options.py
+++ b/docs/py/options/options.py
@@ -8,9 +8,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/order.py
+++ b/docs/py/options/order.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/paging.py
+++ b/docs/py/options/paging.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/row_group.py
+++ b/docs/py/options/row_group.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/options/scroll_x.py
+++ b/docs/py/options/scroll_x.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/scroll_y.py
+++ b/docs/py/options/scroll_y.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/search.py
+++ b/docs/py/options/search.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/search_builder.py
+++ b/docs/py/options/search_builder.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/search_panes.py
+++ b/docs/py/options/search_panes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/select.py
+++ b/docs/py/options/select.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/show_df_type.py
+++ b/docs/py/options/show_df_type.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/show_dtypes.py
+++ b/docs/py/options/show_dtypes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/show_index.py
+++ b/docs/py/options/show_index.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/state_save.py
+++ b/docs/py/options/state_save.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/style.py
+++ b/docs/py/options/style.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/options/text_in_header_can_be_selected.py
+++ b/docs/py/options/text_in_header_can_be_selected.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/other_dataframes.py
+++ b/docs/py/other_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/pandas_dataframes.py
+++ b/docs/py/pandas_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/pandas_style.py
+++ b/docs/py/pandas_style.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/polars_dataframes.py
+++ b/docs/py/polars_dataframes.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% [markdown]

--- a/docs/py/quick_start.py
+++ b/docs/py/quick_start.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/py/troubleshooting.py
+++ b/docs/py/troubleshooting.py
@@ -9,9 +9,9 @@
 #       format_name: percent
 #       format_version: '1.3'
 #   kernelspec:
-#     display_name: itables
+#     display_name: python3
 #     language: python
-#     name: itables
+#     name: python3
 # ---
 
 # %% tags=["remove-cell"]

--- a/docs/quarto/quarto_html.qmd
+++ b/docs/quarto/quarto_html.qmd
@@ -13,9 +13,9 @@ jupyter:
       format_version: '1.0'
       jupytext_version: 1.16.1
   kernelspec:
-    display_name: itables
+    display_name: python3
     language: python
-    name: itables
+    name: python3
 ---
 
 ## How to use ITables in Quarto

--- a/docs/quarto/quarto_revealjs.qmd
+++ b/docs/quarto/quarto_revealjs.qmd
@@ -13,9 +13,9 @@ jupyter:
       format_version: '1.0'
       jupytext_version: 1.16.1
   kernelspec:
-    display_name: itables
+    display_name: python3
     language: python
-    name: itables
+    name: python3
 ---
 
 ## How to use ITables in Quarto

--- a/docs/quick_start.md
+++ b/docs/quick_start.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -7,9 +7,9 @@ jupytext:
     format_name: myst
     format_version: 0.13
 kernelspec:
-  display_name: itables
+  display_name: python3
   language: python
-  name: itables
+  name: python3
 ---
 
 ```{code-cell} ipython3


### PR DESCRIPTION
We now use a standard `python3` kernel for the documentation - this removes the need for a custom kernel.