### PR TITLE
Fix zizmor ref-version-mismatch and fail CI on medium+ severity findings

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -29,6 +29,12 @@ jobs:
           persist-credentials: false
       - name: Run zizmor 🌈
         uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+      - name: Fail on medium+ severity findings
+        uses: zizmorcore/zizmor-action@192e21d79ab29983730a13d1382995c2307fbcaa # v0.5.7
+        with:
+          advanced-security: false
+          annotations: true
+          min-severity: medium
 
   pre-commit:
     runs-on: ubuntu-latest

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -31,4 +31,4 @@ jobs:
           # hatchling.plugin.exceptions.UnknownPluginError: Unknown build hook: jupyter-builder
           pixi run -e build hatch build
       - name: Publish
-        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # release/v1
+        uses: pypa/gh-action-pypi-publish@cef221092ed1bacb1cc03d23a2d87d1d172e277b # v1.14.0


### PR DESCRIPTION
The pinned commit for pypa/gh-action-pypi-publish was annotated with the floating branch ref `release/v1` instead of the actual tag it points to (v1.14.0), which zizmor flagged as alert #25. Also add a second zizmor step to continuous-integration.yml that fails the job on medium+ severity findings, since the SARIF/advanced-security step always exits 0 and only surfaces issues as dismissable Security-tab alerts.