### PR TITLE
Fix Polars Categorical columns with Polars 1.32+ (#607)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,6 +1,13 @@
 ITables ChangeLog
 =================
 
+2.9.1 (unreleased)
+------------------
+
+**Fixed**
+- We have fixed the display of Polars `Categorical` columns with Polars 1.32 and above ([#607](https://github.com/mwouts/itables/issues/607)).
+
+
 2.9.0 (2026-07-19)
 ------------------
 

--- a/src/itables/datatables_format.py
+++ b/src/itables/datatables_format.py
@@ -51,6 +51,30 @@ def _format_pandas_series(
     return formatted
 
 
+def _polars_categories(x) -> "list[Any]":
+    """Return the ordered categories of a Polars Categorical or Enum series"""
+    pl = sys.modules["polars"]
+    if x.dtype == pl.Enum:
+        return x.dtype.categories.to_list()
+    # Since Polars 1.32 the categories of a Categorical live in a process-global
+    # registry, so neither 'dtype' nor 'cat.get_categories()' can tell us which
+    # categories this particular column uses. We collect them from the values, and
+    # sort them, which is reproducible and consistent with how Polars itself sorts
+    # a Categorical column #607
+    return sorted(x.unique().drop_nulls().to_list())
+
+
+def _narwhals_categories(x) -> "list[Any]":
+    """Return the ordered categories of a Narwhals Categorical or Enum series"""
+    nw = sys.modules["narwhals"]
+    if isinstance(x.dtype, nw.Enum):
+        # Narwhals only exposes the categories of an Enum since v2
+        categories = getattr(x.dtype, "categories", None)
+        if categories is not None:
+            return list(categories)
+    return sorted(x.unique().drop_nulls().to_list())
+
+
 def _format_polars_series(
     x,
     escape_html: bool,
@@ -83,9 +107,21 @@ def _format_polars_series(
         formatted = x.to_list()
     elif dtype == pl.Enum or dtype == pl.Categorical:
         if add_rank_to_categories:
-            codes = x.to_physical().to_list()
-            # null gets rank 0 (sorts first), categories are 1-indexed
-            return [0 if c is None else c + 1 for c in codes]
+            if dtype == pl.Enum:
+                # The physical representation of an Enum is the index of the value
+                # in dtype.categories, i.e. in _polars_categories(x)
+                codes = x.to_physical().to_list()
+                # null gets rank 0 (sorts first), categories are 1-indexed
+                return [0 if c is None else c + 1 for c in codes]
+            # The physical representation of a Categorical is a global category id
+            # (#607), so we rank the values against the categories of that column
+            category_to_rank = {
+                cat: i + 1 for i, cat in enumerate(_polars_categories(x))
+            }
+            return [
+                0 if v is None else category_to_rank[v]
+                for v in x.cast(pl.String).to_list()
+            ]
         formatted = x.cast(pl.String).to_list()
     else:
         # Other types - use Polars' native formatting
@@ -158,7 +194,7 @@ def _format_narwhals_series(
 
     # Categorical and Enum types
     if isinstance(dtype, (nw.Categorical, nw.Enum)) and add_rank_to_categories:
-        categories = x.cat.get_categories().to_list()
+        categories = _narwhals_categories(x)
         category_to_rank = {cat: i + 1 for i, cat in enumerate(categories)}
         # null gets rank 0 (sorts first), categories are 1-indexed
         return [0 if v is None else category_to_rank.get(v, 0) for v in x.to_list()]

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -12,7 +12,12 @@ from typing import Any, Literal, Mapping, Optional, Sequence, Union, cast
 
 import itables.options as opt
 
-from .datatables_format import datatables_rows, escape_html_chars
+from .datatables_format import (
+    _narwhals_categories,
+    _polars_categories,
+    datatables_rows,
+    escape_html_chars,
+)
 from .downsample import downsample
 from .typing import (
     DataFrameModuleName,
@@ -1039,7 +1044,7 @@ def get_categorical_columns_to_be_represented_through_their_rank(
         pl = sys.modules["polars"]
 
         categorical_columns = {
-            i: df[col].cat.get_categories().to_list()
+            i: _polars_categories(df[col])
             for i, col in enumerate(df.columns)
             if df[col].dtype in (pl.Categorical, pl.Enum)
         }
@@ -1049,7 +1054,7 @@ def get_categorical_columns_to_be_represented_through_their_rank(
         nw_df = nw.from_native(df, eager_only=True, allow_series=True)
 
         categorical_columns = {
-            i: nw_df[col].cat.get_categories().to_list()
+            i: _narwhals_categories(nw_df[col])
             for i, col in enumerate(nw_df.columns)
             if isinstance(nw_df[col].dtype, (nw.Categorical, nw.Enum))
         }

--- a/src/itables/version.py
+++ b/src/itables/version.py
@@ -1,4 +1,4 @@
 """ITables' version number"""
 
 # Must match [N!]N(.N)*[{a|b|rc}N][.postN][.devN], cf. PEP 440
-__version__ = "2.9.0"
+__version__ = "2.9.1.dev0"

--- a/tests/test_datatables_format.py
+++ b/tests/test_datatables_format.py
@@ -715,5 +715,6 @@ def test_polars_categorical_with_missing_values():
     dt_args = get_itable_arguments(df)
     assert "data_json" in dt_args
     data = json.loads(dt_args["data_json"])
-    # Polars assigns codes in insertion order: b=0→rank 1, a=1→rank 2; null=rank 0
-    assert data == [[1], [0], [2]]
+    # A polars Categorical has no category order, so we sort the categories
+    # alphabetically: null sorts first (rank 0), then a=1, b=2
+    assert data == [[2], [0], [1]]

--- a/tests/test_sample_polars_dfs.py
+++ b/tests/test_sample_polars_dfs.py
@@ -182,6 +182,22 @@ def test_polars_df_with_categorical_and_enums():
     assert dt_args["columnDefs"][1]["targets"] == 1
 
 
+def test_polars_categories_do_not_leak_from_one_df_to_the_next():
+    """Since Polars 1.32 the categories of a Categorical are held in a process-global
+    registry, so we must not use them as-is for a given column #607"""
+    df1 = pl.DataFrame({"cat": pl.Series(["a", "b", "a", "c"], dtype=pl.Categorical)})
+    df2 = pl.DataFrame({"other": pl.Series(["zz", "yy"], dtype=pl.Categorical)})
+
+    get_itable_arguments(df1)
+    dt_args = get_itable_arguments(df2)
+    assert "data_json" in dt_args
+    assert "columnDefs" in dt_args
+
+    # Only the categories of 'other', in alphabetical order: yy=1, zz=2
+    assert dt_args["data_json"] == "[[2], [1]]"
+    assert '["yy", "zz"]' in dt_args["columnDefs"][0]["render"]
+
+
 def test_polars_df_with_nan_and_none():
     df = pl.DataFrame(
         {


### PR DESCRIPTION
Since Polars 1.32 the categories of a Categorical live in a process-global registry, so `cat.get_categories()` returns every category created in the process, and `to_physical()` returns global ids. Categorical columns were therefore embedding unrelated dataframes' categories in their columnDefs, and sorting on the order in which categories happened to be created process-wide.

The categories of a column are now derived from its own values, sorted alphabetically - which is reproducible and matches how Polars itself sorts a Categorical. Enum columns keep the order of dtype.categories. This also drops the last use of `cat.get_categories()`, deprecated in Polars 1.43, which was failing the CI.