### PR TITLE
Check the option names and types when options are set (#601)

### DIFF
--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -4,6 +4,10 @@ ITables ChangeLog
 2.9.1 (unreleased)
 ------------------
 
+**Changed**
+- The options set on `itables.options` are now checked as they are assigned, rather than only when the next table is rendered. A typo in an option name, or an option with an unexpected type, is now reported at the assignment itself ([#601](https://github.com/mwouts/itables/issues/601)).
+- The type of the options passed to e.g. `show` is now checked before itables transforms them, so that the warning quotes the option as you wrote it. Also, every item of a collection is now checked (rather than just the first one as was previously the case)
+
 **Fixed**
 - We have fixed the display of Polars `Categorical` columns with Polars 1.32 and above ([#607](https://github.com/mwouts/itables/issues/607)).
 

--- a/docs/options/options.md
+++ b/docs/options/options.md
@@ -49,4 +49,6 @@ You can also change the default options for all your notebooks and applications 
 
 Option names and types are checked by default at runtime when `typeguard>=4.4.1` is installed. You can disable this by setting `warn_on_undocumented_option=False`.
 
+The check occurs both when you set an option on `itables.options`, and when you pass an option to e.g. `show`.
+
 If you find an option that is useful but undocumented, or if you notice an incorrect type hint, please submit a PR (and consider adding an example to the documentation, too).

--- a/docs/py/options/options.py
+++ b/docs/py/options/options.py
@@ -51,4 +51,6 @@
 #
 # Option names and types are checked by default at runtime when `typeguard>=4.4.1` is installed. You can disable this by setting `warn_on_undocumented_option=False`.
 #
+# The check occurs both when you set an option on `itables.options`, and when you pass an option to e.g. `show`.
+#
 # If you find an option that is useful but undocumented, or if you notice an incorrect type hint, please submit a PR (and consider adding an example to the documentation, too).

--- a/src/itables/javascript.py
+++ b/src/itables/javascript.py
@@ -950,6 +950,27 @@ def _evaluate_show_dtypes(
     return False
 
 
+def _check_column_defs(
+    columnDefs: Sequence[Mapping[str, Any]],
+) -> Sequence[Mapping[str, Any]]:
+    """Make sure that columnDefs is a sequence of column definitions.
+
+    Most DataTables options are simply passed on to DataTables, but columnDefs
+    is one that itables reads, and to which it adds its own column definitions,
+    so we can't do anything sensible with an invalid value (#601)."""
+    invalid = [col_def for col_def in columnDefs if not isinstance(col_def, Mapping)]
+    if invalid:
+        msg = (
+            "The 'columnDefs' option must be a sequence of column definitions "
+            "(see https://datatables.net/reference/option/columnDefs), i.e. of dicts "
+            f"like {{'targets': 0, 'className': 'dt-center'}}, but it contains {invalid[0]!r}."
+        )
+        if isinstance(invalid[0], (list, tuple)):
+            msg += " Did you wrap the column definitions in an extra list or tuple?"
+        raise TypeError(msg)
+    return columnDefs
+
+
 def _remove_columns_with_render_in_columndefs(
     column_set: set[int],
     n_columns: int,
@@ -1221,7 +1242,7 @@ def get_itable_arguments(
         # an extra empty column in the table data #141
         column_count = _column_count_in_header(table_header)
         dt_args["table_html"] = table_header
-        columnDefs = dt_args.get("columnDefs") or []
+        columnDefs = _check_column_defs(dt_args.get("columnDefs") or [])
         float_columns_to_be_formatted_in_python: set[int] = (
             get_float_columns_to_be_formatted_in_python(
                 df_module_name, df, format_floats_in_python, columnDefs
@@ -1504,15 +1525,11 @@ def set_default_options(
                 )
             )
 
-    # The options for ITable in dt_for_itables will be checked later on
-    check_itable_arguments(
-        {
-            k: v
-            for k, v in kwargs.items()
-            if k not in DTForITablesOptions.__optional_keys__
-        },
-        ITableOptions,
-    )
+    # We check every option here, including the ones that will be passed on to
+    # ITable in dt_for_itables and checked again there, because some of them
+    # (e.g. columnDefs) are transformed in between - checking them here is what
+    # lets us report the option as the user wrote it (#601)
+    check_itable_arguments(cast(dict[str, Any], kwargs), ITableOptions)
 
 
 def html_table_from_template(

--- a/src/itables/options.py
+++ b/src/itables/options.py
@@ -5,7 +5,9 @@ These parameters are documented at
 https://itables.org/options/options.html
 """
 
+import sys
 from pathlib import Path
+from types import ModuleType
 from typing import Any, Literal, Mapping, Optional, Sequence, Union
 
 import itables.config as config
@@ -209,3 +211,27 @@ if warn_on_unexpected_option_type:
         },
         typing.ITableOptions,
     )
+
+_non_options = __non_options
+
+
+class _ITableOptionsModule(ModuleType):
+    """The class of the itables.options module.
+
+    Options set on this module are checked as they are assigned, so that
+    e.g. a typo in an option name, or an option with an unexpected type,
+    is reported at the assignment rather than (possibly) much later, when
+    a table is rendered ([#601](https://github.com/mwouts/itables/issues/601)).
+    """
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        super().__setattr__(name, value)
+        if name.startswith("_") or name in _non_options:
+            return
+        if getattr(self, "warn_on_undocumented_option", False):
+            typing.check_itable_argument_names({name}, typing.ITableOptions)
+        if getattr(self, "warn_on_unexpected_option_type", False):
+            typing.check_itable_argument_types({name: value}, typing.ITableOptions)
+
+
+sys.modules[__name__].__class__ = _ITableOptionsModule

--- a/src/itables/typing.py
+++ b/src/itables/typing.py
@@ -318,7 +318,7 @@ def check_itable_argument_types(kwargs: dict[str, Any], typed_dict: type) -> Non
     match the types defined in the given TypedDict.
     """
     try:
-        from typeguard import TypeCheckError, check_type
+        from typeguard import CollectionCheckStrategy, TypeCheckError, check_type
     except ImportError as e:
         raise ImportError(
             "The `warn_on_unexpected_option_type` option requires the 'typeguard' package. "
@@ -332,7 +332,13 @@ def check_itable_argument_types(kwargs: dict[str, Any], typed_dict: type) -> Non
             continue
 
         try:
-            check_type({key: value}, typed_dict)
+            # the options are small, so we can afford to check every item of
+            # e.g. the columnDefs, rather than just the first one (#601)
+            check_type(
+                {key: value},
+                typed_dict,
+                collection_check_strategy=CollectionCheckStrategy.ALL_ITEMS,
+            )
         except TypeCheckError as e:
             type_repr = str(typed_dict.__annotations__[key]).replace("typing.", "")
             warnings.warn(

--- a/tests/test_typing.py
+++ b/tests/test_typing.py
@@ -1,4 +1,5 @@
 import re
+import warnings
 
 import pytest
 
@@ -24,3 +25,58 @@ def test_warns_on_incorrect_option(df):
 def test_warns_on_incorrect_type(df):
     with pytest.warns(SyntaxWarning, match=re.escape("does not match")):
         itables.to_html_datatable(df, lengthMenu=[2.2])  # type: ignore
+
+
+"""The column definitions wrapped in an extra tuple, e.g. because of a stray
+comma when setting itables.options.columnDefs (#601)"""
+COLUMN_DEFS_IN_A_TUPLE = ([{"className": "dt-center", "targets": "_all"}],)
+
+
+def test_warns_on_column_defs_in_a_tuple(df):
+    # every item of a collection is checked, not just the first one, and the
+    # option is reported as the user wrote it, i.e. before itables adds its
+    # own column definitions to it (#601)
+    with pytest.warns(
+        SyntaxWarning,
+        match=re.escape(f"columnDefs={COLUMN_DEFS_IN_A_TUPLE} does not match"),
+    ):
+        with pytest.raises(TypeError, match="extra list or tuple"):
+            itables.to_html_datatable(df, columnDefs=COLUMN_DEFS_IN_A_TUPLE)  # type: ignore
+
+
+def test_raises_on_column_defs_in_a_tuple(df):
+    # itables reads and completes the column definitions, so unlike most
+    # DataTables options they can't just be passed on as they are (#601)
+    with pytest.warns(SyntaxWarning):
+        with pytest.raises(
+            TypeError, match=re.escape("must be a sequence of column definitions")
+        ):
+            itables.to_html_datatable(df, columnDefs=COLUMN_DEFS_IN_A_TUPLE)  # type: ignore
+
+
+def test_warns_when_an_option_is_set(monkeypatch):
+    # options are checked when they are set, so that the warning points at
+    # the assignment rather than at the next table (#601)
+    with pytest.warns(
+        SyntaxWarning,
+        match=re.escape(f"columnDefs={COLUMN_DEFS_IN_A_TUPLE} does not match"),
+    ):
+        monkeypatch.setattr(
+            itables.options, "columnDefs", COLUMN_DEFS_IN_A_TUPLE, raising=False
+        )
+
+
+def test_warns_when_an_undocumented_option_is_set(monkeypatch):
+    with pytest.warns(
+        SyntaxWarning,
+        match="These arguments are not documented in ITableOptions: .*'lengthMenuWithTypo'",
+    ):
+        monkeypatch.setattr(
+            itables.options, "lengthMenuWithTypo", [2, 5, 10], raising=False
+        )
+
+
+def test_no_warning_when_a_valid_option_is_set(monkeypatch):
+    with warnings.catch_warnings():
+        warnings.simplefilter("error")
+        monkeypatch.setattr(itables.options, "lengthMenu", [2, 5, 10], raising=False)


### PR DESCRIPTION
itables.options is now an instance of a ModuleType subclass that checks the option name and type on assignment, so that a typo in an option name, or an option with an unexpected type, is reported at the assignment itself rather than (possibly much later) when a table is rendered.

The options passed to e.g. show are now checked before itables transforms them, so that the warning quotes the option as the user wrote it, and every item of a collection is now checked rather than just the first one.